### PR TITLE
refactor: forward submit to a remote endpoint

### DIFF
--- a/internal/api/tx.go
+++ b/internal/api/tx.go
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -124,17 +123,12 @@ func (a *Api) handleTxSubmit(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close() //nolint:errcheck
 
-	submit, err := txbuilder.OgmiosClient().
-		SubmitTx(context.Background(), hex.EncodeToString(txRawBytes))
+	txHash, err := txbuilder.SubmitTx(txRawBytes)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("%s", err), http.StatusBadRequest)
 		return
 	}
-	if submit.Error != nil {
-		http.Error(w, submit.Error.Message, submit.Error.Code)
-		return
-	}
 	w.Header().Set("Content-Type", "application/json")
-	resp, _ := json.Marshal(submit.ID)
+	resp, _ := json.Marshal(txHash)
 	_, _ = w.Write(resp)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,7 @@ type ApiConfig struct {
 type TxBuilderConfig struct {
 	KupoUrl         string `yaml:"kupoUrl"         envconfig:"TXBUILDER_KUPO_URL"`
 	OgmiosUrl       string `yaml:"ogmiosUrl"       envconfig:"TXBUILDER_OGMIOS_URL"`
+	SubmitUrl       string `yaml:"submitUrl"       envconfig:"TXBUILDER_SUBMIT_URL"`
 	ProviderAddress string `yaml:"providerAddress" envconfig:"TXBUILDER_PROVIDER_ADDRESS"`
 	ScriptRefInput  string `yaml:"scriptRefInput"  envconfig:"TXBUILDER_SCRIPT_REF_INPUT"`
 }

--- a/internal/txbuilder/submit.go
+++ b/internal/txbuilder/submit.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txbuilder
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/blinklabs-io/vpn-indexer/internal/config"
+)
+
+func SubmitTx(txRawBytes []byte) (string, error) {
+	cfg := config.GetConfig()
+	client := createHTTPClient()
+	body := bytes.NewBuffer(txRawBytes)
+	req, err := http.NewRequest(
+		http.MethodPost,
+		cfg.TxBuilder.SubmitUrl,
+		body,
+	)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Content-Type", "application/cbor")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if resp.StatusCode == http.StatusAccepted {
+		return string(respBody), nil
+	}
+	return "", errors.New("empty body returned")
+}
+
+// createHTTPClient with custom timeout
+func createHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 60 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			DisableCompression:    false,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}


### PR DESCRIPTION
Rather than reuse the Apollo Ogmios, submit directly to a remote submit API endpoint.