### PR TITLE
feat(internal): disable_kupo_logging

### DIFF
--- a/internal/txbuilder/txbuilder.go
+++ b/internal/txbuilder/txbuilder.go
@@ -48,6 +48,7 @@ func apolloBackend() (*OgmiosChainContext.OgmiosChainContext, error) {
 	kupoClient := kugo.New(
 		kugo.WithEndpoint(cfg.TxBuilder.KupoUrl),
 		kugo.WithTimeout(defaultKupoTimeout),
+		kugo.WithLogger(ogmigo.NopLogger),
 	)
 	occ := OgmiosChainContext.NewOgmiosChainContext(*ogmiosClient, *kupoClient)
 	return &occ, nil


### PR DESCRIPTION
1. Disabled verbose Kupo match query logs by adding in ogmigo.NopLogger via WithLogger in kugo instance.

Closes #117 