### PR TITLE
refactor: update for new preprod contract

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -352,6 +352,55 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/tx/transfer": {
+            "post": {
+                "description": "Build a transaction for a VPN transfer",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "TxTransfer",
+                "parameters": [
+                    {
+                        "description": "Transfer Request",
+                        "name": "TxTransferRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.TxTransferRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Built transaction",
+                        "schema": {
+                            "$ref": "#/definitions/api.TxTransferResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -430,20 +479,20 @@ const docTemplate = `{
         "api.TxRenewRequest": {
             "type": "object",
             "properties": {
-                "clientAddress": {
-                    "type": "string"
-                },
                 "clientId": {
                     "type": "string"
                 },
                 "duration": {
                     "type": "integer"
                 },
+                "ownerAddress": {
+                    "type": "string"
+                },
+                "paymentAddress": {
+                    "type": "string"
+                },
                 "price": {
                     "type": "integer"
-                },
-                "region": {
-                    "type": "string"
                 }
             }
         },
@@ -482,6 +531,28 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "api.TxTransferRequest": {
+            "type": "object",
+            "properties": {
+                "clientId": {
+                    "type": "string"
+                },
+                "ownerAddress": {
+                    "type": "string"
+                },
+                "paymentAddress": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.TxTransferResponse": {
+            "type": "object",
+            "properties": {
+                "txCbor": {
+                    "type": "string"
+                }
+            }
         }
     }
 }`
@@ -496,6 +567,8 @@ var SwaggerInfo = &swag.Spec{
 	Description:      "NABU VPN indexer API",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
+	LeftDelim:        "{{",
+	RightDelim:       "}}",
 }
 
 func init() {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -345,6 +345,55 @@
                     }
                 }
             }
+        },
+        "/api/tx/transfer": {
+            "post": {
+                "description": "Build a transaction for a VPN transfer",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "TxTransfer",
+                "parameters": [
+                    {
+                        "description": "Transfer Request",
+                        "name": "TxTransferRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.TxTransferRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Built transaction",
+                        "schema": {
+                            "$ref": "#/definitions/api.TxTransferResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -423,20 +472,20 @@
         "api.TxRenewRequest": {
             "type": "object",
             "properties": {
-                "clientAddress": {
-                    "type": "string"
-                },
                 "clientId": {
                     "type": "string"
                 },
                 "duration": {
                     "type": "integer"
                 },
+                "ownerAddress": {
+                    "type": "string"
+                },
+                "paymentAddress": {
+                    "type": "string"
+                },
                 "price": {
                     "type": "integer"
-                },
-                "region": {
-                    "type": "string"
                 }
             }
         },
@@ -471,6 +520,28 @@
                 "clientId": {
                     "type": "string"
                 },
+                "txCbor": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.TxTransferRequest": {
+            "type": "object",
+            "properties": {
+                "clientId": {
+                    "type": "string"
+                },
+                "ownerAddress": {
+                    "type": "string"
+                },
+                "paymentAddress": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.TxTransferResponse": {
+            "type": "object",
+            "properties": {
                 "txCbor": {
                     "type": "string"
                 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -48,16 +48,16 @@ definitions:
     type: object
   api.TxRenewRequest:
     properties:
-      clientAddress:
-        type: string
       clientId:
         type: string
       duration:
         type: integer
+      ownerAddress:
+        type: string
+      paymentAddress:
+        type: string
       price:
         type: integer
-      region:
-        type: string
     type: object
   api.TxRenewResponse:
     properties:
@@ -79,6 +79,20 @@ definitions:
     properties:
       clientId:
         type: string
+      txCbor:
+        type: string
+    type: object
+  api.TxTransferRequest:
+    properties:
+      clientId:
+        type: string
+      ownerAddress:
+        type: string
+      paymentAddress:
+        type: string
+    type: object
+  api.TxTransferResponse:
+    properties:
       txCbor:
         type: string
     type: object
@@ -310,4 +324,36 @@ paths:
           schema:
             type: string
       summary: TxSubmit
+  /api/tx/transfer:
+    post:
+      consumes:
+      - application/json
+      description: Build a transaction for a VPN transfer
+      parameters:
+      - description: Transfer Request
+        in: body
+        name: TxTransferRequest
+        required: true
+        schema:
+          $ref: '#/definitions/api.TxTransferRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Built transaction
+          schema:
+            $ref: '#/definitions/api.TxTransferResponse'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "405":
+          description: Method Not Allowed
+          schema:
+            type: string
+        "500":
+          description: Server Error
+          schema:
+            type: string
+      summary: TxTransfer
 swagger: "2.0"

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -77,6 +77,7 @@ func Start(cfg *config.Config, db *database.Database, ca *ca.Ca) error {
 	mainMux.HandleFunc("/api/refdata", api.handleRefData)
 	mainMux.HandleFunc("/api/tx/signup", api.handleTxSignup)
 	mainMux.HandleFunc("/api/tx/renew", api.handleTxRenew)
+	mainMux.HandleFunc("/api/tx/transfer", api.handleTxTransfer)
 	mainMux.HandleFunc("/api/tx/submit", api.handleTxSubmit)
 
 	// Wrap the mainMux with a CORS middleware

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,10 +126,10 @@ var globalConfig = &Config{
 	Indexer: IndexerConfig{
 		Network: "preprod",
 		// NOTE: these values correspond to the block before the reference token and/or script used below appear on-chain
-		IntersectSlot:  103_106_880,
-		IntersectHash:  "f111144737e0998f6f696aebcb82e769a91c57684fbcaaa101226a75901bc481",
-		ScriptAddress:  "addr_test1zzcktgj2c0fsdaqnlhvevcn9sjmwserytt7g0l82pxcvrn2jduk3c6ecrpkrk8qqlr4ep37cx03ytlcn70n93zyemj6sfgz2vs",
-		ReferenceToken: "eddc8f734e487da2204993bd3fb2a6228307c52df2ce0384506d2038.70726f7669646572",
+		IntersectSlot:  103_741_833,
+		IntersectHash:  "753cd54fc17ccc12c2db99598246e19029bbea9a17dc1a38eb27b9280d3379d6",
+		ScriptAddress:  "addr_test1zrdf6wkqjlu6urqtmyeafczgfrl9hhs4hw7usm9slvgzy26jduk3c6ecrpkrk8qqlr4ep37cx03ytlcn70n93zyemj6svnkmku",
+		ReferenceToken: "f043e77d22674a36edfbda3200a6ba9eb966c045ed72eb427cf45c92.70726f7669646572",
 	},
 	Database: DatabaseConfig{
 		Directory: "./.vpn-indexer",
@@ -150,7 +150,7 @@ var globalConfig = &Config{
 	TxBuilder: TxBuilderConfig{
 		// NOTE: this shares a stake key with the indexer script address
 		ProviderAddress: "addr_test1qpjwevqy6mh5hsnudjgpgrtfjwwxdtl7d73e9u0kxg9453jjduk3c6ecrpkrk8qqlr4ep37cx03ytlcn70n93zyemj6sasxnj5",
-		ScriptRefInput:  "bbbe818c99e248c305a0d0ebad7508974f37e342833c55bc0242dcdfbaa2848c#1",
+		ScriptRefInput:  "363fb149456226998f537df63cdfbab015ae4a10cb45bf427b89ffbc53f484c3#1",
 	},
 }
 

--- a/scripts/test-api.sh
+++ b/scripts/test-api.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+set -eo pipefail
+
+API_BASE=http://localhost:8080/api
+
+SUBMIT_URL=${SUBMIT_URL:-}
+
+USER1_ADDR=${USER1_ADDR:-}
+USER1_SKEY_FILE=${USER1_SKEY_FILE:-}
+USER2_ADDR=${USER2_ADDR:-}
+USER2_SKEY_FILE=${USER2_SKEY_FILE:-}
+
+_region='us east-1'
+_price=5000000
+_duration=259200000
+
+txHexToJson() {
+	local tx_hex=$1
+	local out_file=$2
+
+	echo '{ "type": "Unwitnessed Tx ConwayEra", "description": "Ledger Cddl Format", "cborHex": "'${tx_hex}'" }' > ${out_file}
+}
+
+txJsonToRaw() {
+	local tx_file=$1
+	local out_file=$2
+
+	jq -r .cborHex ${tx_file} | xxd -r -p > ${out_file}
+}
+
+signTx() {
+	local tx_file=$1
+	local skey_file=$2
+	local out_file=$3
+
+	echo "*** Signing transaction"
+	cardano-cli latest transaction sign --tx-file ${tx_file} --signing-key-file ${skey_file} --out-file ${out_file}
+}
+
+submitTx() {
+	local raw_tx_file=$1
+
+	echo "*** Submitting transaction"
+	if ! curl -s --fail-with-body -H "Content-type: application/cbor" ${SUBMIT_URL} --data-binary @${raw_tx_file}; then
+		echo
+		echo "*** Failed to submit TX with CBOR:"
+		echo
+		xxd -c 0 -p ${raw_tx_file}
+		exit 1
+	fi
+	echo
+}
+
+apiClientList() {
+	local owner_addr=$1
+	local client_id=$2
+
+	curl -s ${API_BASE}/client/list -d '{"clientAddress":"'${owner_addr}'"}' |
+		jq '.[] | select(.id == "'${client_id}'")'
+}
+
+apiWaitForClient() {
+	local owner_addr=$1
+	local client_id=$2
+
+	echo "*** Waiting for client ${client_id} with owner address ${owner_addr}"
+	while true; do
+		if apiClientList ${owner_addr} ${client_id} | \
+			grep -q ${client_id}; then
+			break
+		fi
+		sleep 10
+	done
+}
+
+apiWaitForClientExpiry() {
+	local owner_addr=$1
+	local client_id=$2
+	local old_expiry=$3
+
+	echo "*** Waiting for client ${client_id} with owner address ${owner_addr} with updated expiry"
+	while true; do
+		if ! apiClientList ${owner_addr} ${client_id} | jq -r .expiration | \
+			grep -q "${old_expiry}"; then
+			break
+		fi
+		sleep 10
+	done
+}
+
+if [[ ! $SUBMIT_URL ]]; then
+	echo "You must provide the SUBMIT_URL env var"
+	exit 1
+fi
+
+if [[ ! $USER1_ADDR || ! $USER1_SKEY_FILE || ! $USER2_ADDR || ! $USER2_SKEY_FILE ]]; then
+	echo "You must provide the USER1_ADDR, USER1_SKEY_FILE, USER2_ADDR, and USER2_SKEY_FILE env vars"
+	exit 1
+fi
+
+_tmpdir=$(mktemp -d)
+
+#trap 'rm -rf ${_tmpdir}' EXIT
+
+# Signup for user1
+echo "*** Generating TX for signup for user1"
+(
+set -x
+curl -s --fail-with-body ${API_BASE}/tx/signup -d '{"clientAddress":"'${USER1_ADDR}'","region":"'"${_region}"'","price":'${_price}',"duration":'${_duration}'}' > ${_tmpdir}/user1_api_signup.json
+)
+_client_id=$(jq -r .clientId ${_tmpdir}/user1_api_signup.json)
+txHexToJson $(jq -r .txCbor ${_tmpdir}/user1_api_signup.json) ${_tmpdir}/user1_tx_signup_unsigned.json
+signTx ${_tmpdir}/user1_tx_signup_unsigned.json ${USER1_SKEY_FILE} ${_tmpdir}/user1_tx_signup_signed.json
+txJsonToRaw ${_tmpdir}/user1_tx_signup_signed.json ${_tmpdir}/user1_tx_signup_signed.raw
+submitTx ${_tmpdir}/user1_tx_signup_signed.raw
+apiWaitForClient ${USER1_ADDR} ${_client_id}
+apiClientList ${USER1_ADDR} ${_client_id} | jq .
+
+# Transfer from user1 to user2
+echo "*** Generating TX for transfer from user1 to user2"
+(
+set -x
+curl -s --fail-with-body ${API_BASE}/tx/transfer -d '{"paymentAddress":"'${USER1_ADDR}'","ownerAddress":"'${USER2_ADDR}'","clientId":"'${_client_id}'"}' > ${_tmpdir}/user1_api_transfer_user2.json
+)
+txHexToJson $(jq -r .txCbor ${_tmpdir}/user1_api_transfer_user2.json) ${_tmpdir}/user1_tx_transfer_user2_unsigned.json
+signTx ${_tmpdir}/user1_tx_transfer_user2_unsigned.json ${USER1_SKEY_FILE} ${_tmpdir}/user1_tx_transfer_user2_signed.json
+txJsonToRaw ${_tmpdir}/user1_tx_transfer_user2_signed.json ${_tmpdir}/user1_tx_transfer_user2_signed.raw
+submitTx ${_tmpdir}/user1_tx_transfer_user2_signed.raw
+apiWaitForClient ${USER2_ADDR} ${_client_id}
+apiClientList ${USER2_ADDR} ${_client_id} | jq .
+
+# Renew for user2
+echo "*** Generating TX for renew for user2"
+(
+set -x
+curl -s --fail-with-body ${API_BASE}/tx/renew -d '{"paymentAddress":"'${USER2_ADDR}'","region":"'"${_region}"'","price":'${_price}',"duration":'${_duration}',"clientId":"'${_client_id}'"}' > ${_tmpdir}/user2_api_renew.json
+)
+_old_expiry=$(apiClientList ${USER2_ADDR} ${_client_id} | jq -r .expiration)
+txHexToJson $(jq -r .txCbor ${_tmpdir}/user2_api_renew.json) ${_tmpdir}/user2_tx_renew_unsigned.json
+signTx ${_tmpdir}/user2_tx_renew_unsigned.json ${USER2_SKEY_FILE} ${_tmpdir}/user2_tx_renew_signed.json
+txJsonToRaw ${_tmpdir}/user2_tx_renew_signed.json ${_tmpdir}/user2_tx_renew_signed.raw
+submitTx ${_tmpdir}/user2_tx_renew_signed.raw
+apiWaitForClientExpiry ${USER2_ADDR} ${_client_id} "${_old_expiry}"
+apiClientList ${USER2_ADDR} ${_client_id}
+
+# Renew and transfer from user2 to user1
+echo "*** Generating TX for renew and transfer from user2 to user1"
+(
+set -x
+curl -s --fail-with-body ${API_BASE}/tx/renew -d '{"paymentAddress":"'${USER2_ADDR}'","ownerAddress":"'${USER1_ADDR}'","region":"'"${_region}"'","price":'${_price}',"duration":'${_duration}',"clientId":"'${_client_id}'"}' > ${_tmpdir}/user2_api_renew_transfer_user1.json 
+)
+txHexToJson $(jq -r .txCbor ${_tmpdir}/user2_api_renew_transfer_user1.json) ${_tmpdir}/user2_tx_renew_transfer_user1_unsigned.json
+signTx ${_tmpdir}/user2_tx_renew_transfer_user1_unsigned.json ${USER2_SKEY_FILE} ${_tmpdir}/user2_tx_renew_transfer_user1_signed.json
+txJsonToRaw ${_tmpdir}/user2_tx_renew_transfer_user1_signed.json ${_tmpdir}/user2_tx_renew_transfer_user1_signed.raw
+submitTx ${_tmpdir}/user2_tx_renew_transfer_user1_signed.raw
+apiWaitForClient ${USER1_ADDR} ${_client_id}
+apiClientList ${USER1_ADDR} ${_client_id} | jq .
+
+# Renew for user1 paid by user2
+echo "*** Generating TX for renew for user1 paid by user2"
+(
+set -x
+curl -s --fail-with-body ${API_BASE}/tx/renew -d '{"paymentAddress":"'${USER2_ADDR}'","region":"'"${_region}"'","price":'${_price}',"duration":'${_duration}',"clientId":"'${_client_id}'"}' > ${_tmpdir}/user2_api_renew_user1.json
+)
+_old_expiry=$(apiClientList ${USER1_ADDR} ${_client_id} | jq -r .expiration)
+txHexToJson $(jq -r .txCbor ${_tmpdir}/user2_api_renew_user1.json) ${_tmpdir}/user2_tx_renew_user1_unsigned.json
+signTx ${_tmpdir}/user2_tx_renew_user1_unsigned.json ${USER2_SKEY_FILE} ${_tmpdir}/user2_tx_renew_user1_signed.json
+txJsonToRaw ${_tmpdir}/user2_tx_renew_user1_signed.json ${_tmpdir}/user2_tx_renew_user1_signed.raw
+submitTx ${_tmpdir}/user2_tx_renew_user1_signed.raw
+apiWaitForClientExpiry ${USER1_ADDR} ${_client_id} "${_old_expiry}"
+apiClientList ${USER1_ADDR} ${_client_id} | jq .


### PR DESCRIPTION
The renew/transfer logic in the contract has been updated, and this updates the accompanying TX builder logic.

* allow specifying owner address for renew
* remove 'region' param for renew
* add separate transfer API endpoint
* create API testing script

Fixes #156