### PR TITLE
refactor: separate payment/owner address for TX signup endpoint

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -429,7 +429,7 @@ const docTemplate = `{
         "api.ClientListRequest": {
             "type": "object",
             "properties": {
-                "clientAddress": {
+                "ownerAddress": {
                     "type": "string"
                 }
             }
@@ -507,11 +507,14 @@ const docTemplate = `{
         "api.TxSignupRequest": {
             "type": "object",
             "properties": {
-                "clientAddress": {
-                    "type": "string"
-                },
                 "duration": {
                     "type": "integer"
+                },
+                "ownerAddress": {
+                    "type": "string"
+                },
+                "paymentAddress": {
+                    "type": "string"
                 },
                 "price": {
                     "type": "integer"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -422,7 +422,7 @@
         "api.ClientListRequest": {
             "type": "object",
             "properties": {
-                "clientAddress": {
+                "ownerAddress": {
                     "type": "string"
                 }
             }
@@ -500,11 +500,14 @@
         "api.TxSignupRequest": {
             "type": "object",
             "properties": {
-                "clientAddress": {
-                    "type": "string"
-                },
                 "duration": {
                     "type": "integer"
+                },
+                "ownerAddress": {
+                    "type": "string"
+                },
+                "paymentAddress": {
+                    "type": "string"
                 },
                 "price": {
                     "type": "integer"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -16,7 +16,7 @@ definitions:
     type: object
   api.ClientListRequest:
     properties:
-      clientAddress:
+      ownerAddress:
         type: string
     type: object
   api.ClientProfileRequest:
@@ -66,10 +66,12 @@ definitions:
     type: object
   api.TxSignupRequest:
     properties:
-      clientAddress:
-        type: string
       duration:
         type: integer
+      ownerAddress:
+        type: string
+      paymentAddress:
+        type: string
       price:
         type: integer
       region:

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -33,7 +33,7 @@ import (
 
 // ClientListRequest provides the payment credential hash to search
 type ClientListRequest struct {
-	ClientAddress string `json:"clientAddress"`
+	OwnerAddress string `json:"ownerAddress"`
 }
 
 // Client provides the unique identifier, expiration time, and VPN region for
@@ -72,17 +72,17 @@ func (a *Api) handleClientList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientAddr, err := lcommon.NewAddress(req.ClientAddress)
+	ownerAddr, err := lcommon.NewAddress(req.OwnerAddress)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write(
 			[]byte(
-				`{"error":"Invalid request","reason":"invalid client address"}`,
+				`{"error":"Invalid request","reason":"invalid owner address"}`,
 			),
 		)
 		return
 	}
-	paymentKeyHash := clientAddr.PaymentKeyHash().Bytes()
+	paymentKeyHash := ownerAddr.PaymentKeyHash().Bytes()
 	clients, err := a.db.ClientsByCredential(paymentKeyHash)
 	if err != nil {
 		slog.Error(

--- a/internal/api/tx.go
+++ b/internal/api/tx.go
@@ -27,10 +27,11 @@ import (
 
 // TxSignupRequest provides the client address, plan price and duration, and region for the VPN signup
 type TxSignupRequest struct {
-	ClientAddress string `json:"clientAddress"`
-	Price         int    `json:"price"`
-	Duration      int    `json:"duration"`
-	Region        string `json:"region"`
+	PaymentAddress string `json:"paymentAddress"`
+	OwnerAddress   string `json:"ownerAddress"`
+	Price          int    `json:"price"`
+	Duration       int    `json:"duration"`
+	Region         string `json:"region"`
 }
 
 // TxSignupResponse returns an unsigned transaction for a VPN signup
@@ -66,7 +67,8 @@ func (a *Api) handleTxSignup(w http.ResponseWriter, r *http.Request) {
 
 	txCbor, clientId, err := txbuilder.BuildSignupTx(
 		a.db,
-		req.ClientAddress,
+		req.PaymentAddress,
+		req.OwnerAddress,
 		req.Price,
 		req.Duration,
 		req.Region,

--- a/scripts/test-api.sh
+++ b/scripts/test-api.sh
@@ -56,7 +56,7 @@ apiClientList() {
 	local owner_addr=$1
 	local client_id=$2
 
-	curl -s ${API_BASE}/client/list -d '{"clientAddress":"'${owner_addr}'"}' |
+	curl -s ${API_BASE}/client/list -d '{"ownerAddress":"'${owner_addr}'"}' |
 		jq '.[] | select(.id == "'${client_id}'")'
 }
 
@@ -107,7 +107,7 @@ _tmpdir=$(mktemp -d)
 echo "*** Generating TX for signup for user1"
 (
 set -x
-curl -s --fail-with-body ${API_BASE}/tx/signup -d '{"clientAddress":"'${USER1_ADDR}'","region":"'"${_region}"'","price":'${_price}',"duration":'${_duration}'}' > ${_tmpdir}/user1_api_signup.json
+curl -s --fail-with-body ${API_BASE}/tx/signup -d '{"paymentAddress":"'${USER1_ADDR}'","region":"'"${_region}"'","price":'${_price}',"duration":'${_duration}'}' > ${_tmpdir}/user1_api_signup.json
 )
 _client_id=$(jq -r .clientId ${_tmpdir}/user1_api_signup.json)
 txHexToJson $(jq -r .txCbor ${_tmpdir}/user1_api_signup.json) ${_tmpdir}/user1_tx_signup_unsigned.json


### PR DESCRIPTION
This splits clientAddress for signup to payment/ownerAddress like renew. It also renames clientAddress to ownerAddress when listing clients

Fixes #160