### PR TITLE
fix: use consistent cert common name

### DIFF
--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -124,7 +124,7 @@ func (c *Ca) loadKey(cfg *config.Config) error {
 
 func (c *Ca) GenerateClientCert(clientName string) (*ClientCert, error) {
 	// Generate cert serial number from client name
-	clientSerial := ClientNameToSerialNumber([]byte(clientName))
+	clientSerial := ClientNameToSerialNumber(clientName)
 	// Cert template
 	cert := &x509.Certificate{
 		SerialNumber: clientSerial,
@@ -212,10 +212,10 @@ func (c *Ca) GenerateCRL(
 	return ret, nil
 }
 
-func ClientNameToSerialNumber(clientName []byte) *big.Int {
+func ClientNameToSerialNumber(clientName string) *big.Int {
 	// Hash client name using blake2b-160 to use as cert serial number
 	hasher, _ := blake2b.New(20, nil)
-	hasher.Write(clientName)
+	hasher.Write([]byte(clientName))
 	clientNameHash := hasher.Sum(nil)
 	return new(big.Int).SetBytes(clientNameHash)
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -28,7 +28,6 @@ import (
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/blinklabs-io/vpn-indexer/internal/ca"
 	"github.com/blinklabs-io/vpn-indexer/internal/config"
-	"golang.org/x/crypto/blake2b"
 )
 
 const profileTemplate = `
@@ -56,7 +55,6 @@ type Client struct {
 	config    *config.Config
 	ca        *ca.Ca
 	assetName []byte
-	id        string
 }
 
 func New(cfg *config.Config, caObj *ca.Ca, assetName []byte) *Client {
@@ -179,14 +177,5 @@ func (c *Client) createS3Client() (*s3.Client, error) {
 }
 
 func (c *Client) identifier() string {
-	// Returned cached response
-	if c.id != "" {
-		return c.id
-	}
-	// Create blake2b-256 hash from client name and encode as hex
-	hasher, _ := blake2b.New(32, nil)
-	hasher.Write(c.assetName)
-	hash := hasher.Sum(nil)
-	c.id = hex.EncodeToString(hash)
-	return c.id
+	return hex.EncodeToString(c.assetName)
 }

--- a/internal/crl/crl.go
+++ b/internal/crl/crl.go
@@ -114,7 +114,7 @@ func (c *Crl) updateConfigMap() error {
 		revokedCerts = append(
 			revokedCerts,
 			pkix.RevokedCertificate{
-				SerialNumber:   ca.ClientNameToSerialNumber(client.AssetName),
+				SerialNumber:   ca.ClientNameToSerialNumber(hex.EncodeToString(client.AssetName)),
 				RevocationTime: client.Expiration,
 			},
 		)


### PR DESCRIPTION
Use the hex-encoded asset name as the TLS cert common name both when generating the cert and when populating the CRL