### PR TITLE
refactor: trigger CRL update on timer and client update

### DIFF
--- a/cmd/vpn-indexer/main.go
+++ b/cmd/vpn-indexer/main.go
@@ -160,7 +160,7 @@ func main() {
 	}
 
 	// Configure CRL
-	_, err = crl.New(cfg, logger, db, ca)
+	crl, err := crl.New(cfg, logger, db, ca)
 	if err != nil {
 		slog.Error(
 			fmt.Sprintf("failed to configure CRL: %s", err),
@@ -169,7 +169,7 @@ func main() {
 	}
 
 	// Start indexer
-	if err := indexer.GetIndexer().Start(cfg, logger, db, ca); err != nil {
+	if err := indexer.GetIndexer().Start(cfg, logger, db, ca, crl); err != nil {
 		slog.Error(
 			fmt.Sprintf("failed to start indexer: %s", err),
 		)

--- a/scripts/local-deploy.sh
+++ b/scripts/local-deploy.sh
@@ -120,7 +120,7 @@ crl:
   configMapNamespace: vpn-test
   configMapName: test-crl
   configMapKey: crl.pem
-  updateInterval: 1m
+  updateInterval: 2m
 EOF
 
 # Install helm chart


### PR DESCRIPTION
This changes the CRL timer to run once per minute but only trigger the CRL update if the specified interval has elapsed since the last scheduled run or if the indexer has signaled that the CRL should be updated on the next timer tick.

Fixes #167