### PR TITLE
feat(cli): CLI for Transfer Tx Build

### DIFF
--- a/cmd/vpn-cli/transfer.go
+++ b/cmd/vpn-cli/transfer.go
@@ -44,10 +44,6 @@ func runTransfer(cmd *cobra.Command, _ []string) error {
 	if err := validateFormat(format); err != nil {
 		return err
 	}
-	// Normalize inputs
-	flagTransferPayment = strings.TrimSpace(flagTransferPayment)
-	flagTransferOwner = strings.TrimSpace(flagTransferOwner)
-	flagTransferClientID = strings.TrimSpace(flagTransferClientID)
 
 	if flagTransferPayment == "" {
 		return errors.New("--payment is required")


### PR DESCRIPTION
1. Added changes for transfer TX build from CLI.

```
akhil-mac@Akhils-MacBook-Air vpn-indexer % go run ./cmd/vpn-cli --help
Build unsigned transactions for VPN

Usage:
  vpn-cli [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  renew       Build an unsigned renewal transaction
  signup      Build an unsigned signup transaction
  transfer    Build an unsigned transfer transaction

Flags:
      --format string   output format: hex|cbor (default "hex")
  -h, --help            help for vpn-cli
  -o, --out string      output file (default: stdout)

Use "vpn-cli [command] --help" for more information about a command.
akhil-mac@Akhils-MacBook-Air vpn-indexer %
```

```
akhil-mac@Akhils-MacBook-Air vpn-indexer % go run ./cmd/vpn-cli transfer --help
Build an unsigned transfer transaction

Usage:
  vpn-cli transfer [flags]

Flags:
      --client-id string    existing client ID (required)
  -h, --help                help for transfer
      --kupo-url string     Kupo endpoint (used if --refdata not provided)
      --ogmios-url string   Ogmios endpoint (optional)
      --owner string        owner bech32 address (required)
      --payment string      client payment bech32 address (required)

Global Flags:
      --format string   output format: hex|cbor (default "hex")
  -o, --out string      output file (default: stdout)
akhil-mac@Akhils-MacBook-Air vpn-indexer %
```

Closes #174 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "transfer" command to VPN CLI for building unsigned transfer transactions
  * Supports configurable payment, owner, and client identifiers
  * Allows optional Ogmios and Kupo endpoint configuration
  * Outputs CBOR-encoded transaction data to file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->