### PR TITLE
fix: don't consider inputs with assets

### DIFF
--- a/internal/txbuilder/txbuilder.go
+++ b/internal/txbuilder/txbuilder.go
@@ -128,6 +128,11 @@ func chooseInputUtxos(
 			return nil, errors.New("not enough funds")
 		}
 		utxo := availableUtxos[0]
+		// Discard inputs with assets for simplicity
+		if utxo.Output.GetValue().HasAssets {
+			availableUtxos = availableUtxos[1:]
+			continue
+		}
 		ret = append(ret, utxo)
 		selectedAmount = selectedAmount.Add(utxo.Output.GetValue())
 		availableUtxos = availableUtxos[1:]


### PR DESCRIPTION
Fixes #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction input selection to properly exclude UTxOs containing assets, ensuring more reliable transaction construction and preventing potential asset-related conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->