### PR TITLE
feat(txbuilder): Make TTL value configurable

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,7 @@ type TxBuilderConfig struct {
 	SubmitUrl       string `yaml:"submitUrl"       envconfig:"TXBUILDER_SUBMIT_URL"`
 	ProviderAddress string `yaml:"providerAddress" envconfig:"TXBUILDER_PROVIDER_ADDRESS"`
 	ScriptRefInput  string `yaml:"scriptRefInput"  envconfig:"TXBUILDER_SCRIPT_REF_INPUT"`
+	TTLOffset       uint64 `yaml:"ttlOffset"       envconfig:"TXBUILDER_TTL_OFFSET"`
 }
 
 // Singleton config instance with default values
@@ -151,6 +152,7 @@ var globalConfig = &Config{
 		// NOTE: this shares a stake key with the indexer script address
 		ProviderAddress: "addr_test1qpjwevqy6mh5hsnudjgpgrtfjwwxdtl7d73e9u0kxg9453jjduk3c6ecrpkrk8qqlr4ep37cx03ytlcn70n93zyemj6sasxnj5",
 		ScriptRefInput:  "ea7e4f0147eeba9a17c519e1652ed933262d30fe462bf418ece18dc27a2c13ba#1",
+		TTLOffset:       500,
 	},
 }
 

--- a/internal/txbuilder/renew.go
+++ b/internal/txbuilder/renew.go
@@ -251,7 +251,7 @@ func BuildRenewTransferTx(
 		// Set transaction not valid before current slot
 		SetValidityStart(int64(curSlot)).
 		// Set TTL
-		SetTtl(int64(curSlot+transactionTtlSlots)).
+		SetTtl(int64(curSlot)+int64(cfg.TxBuilder.TTLOffset)).
 		// Send service payment to provider address
 		PayToAddress(
 			providerAddress, price,

--- a/internal/txbuilder/signup.go
+++ b/internal/txbuilder/signup.go
@@ -230,7 +230,7 @@ func BuildSignupTx(
 		// Set transaction not valid before current slot
 		SetValidityStart(int64(curSlot)).
 		// Set TTL
-		SetTtl(int64(curSlot+transactionTtlSlots)).
+		SetTtl(int64(curSlot)+int64(cfg.TxBuilder.TTLOffset)).
 		// Send service payment to provider address
 		PayToAddress(
 			providerAddress, price,

--- a/internal/txbuilder/txbuilder.go
+++ b/internal/txbuilder/txbuilder.go
@@ -36,8 +36,7 @@ import (
 )
 
 const (
-	defaultKupoTimeout  = 1 * time.Second
-	transactionTtlSlots = 500
+	defaultKupoTimeout = 1 * time.Second
 )
 
 var systemStart *time.Time


### PR DESCRIPTION
1. Adds a configurable TTL offset to the transaction builder and replaced all hard-coded TTL usage in signup and renewal.

Closes #192 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Transaction TTL offset is now configurable via settings or environment variables, allowing customization of transaction expiration timing while maintaining backward compatibility with existing defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->