### PR TITLE
feat: harden OpenVPN client

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,7 @@ type VpnConfig struct {
 	Domain string `yaml:"domain" envconfig:"VPN_DOMAIN"`
 	Region string `yaml:"region" envconfig:"VPN_REGION"`
 	Port   int    `yaml:"port"   envconfig:"VPN_PORT"`
+	DNS    string `yaml:"dns"    envconfig:"VPN_DNS"`
 }
 
 type CrlConfig struct {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -336,7 +336,7 @@ func (i *Indexer) handleEventClient(txOutput lcommon.Utxo) error {
 		string(clientDatum.Region),
 		i.cfg.Vpn.Domain,
 	)
-	clientId, err := tmpClient.Generate(vpnHost, i.cfg.Vpn.Port)
+	clientId, err := tmpClient.Generate(vpnHost, i.cfg.Vpn.Port, i.cfg.Vpn.DNS)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is the client side of blinklabs-io/vpn-infrastructure#65



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the OpenVPN client config to enforce strong encryption, disable risky features, and improve routing and connection stability. Added configurable DNS with validation and reduced logging noise to further cut DNS/IP leak risk.

- **New Features**
  - TLS 1.3 only with AES-256-GCM and CHACHA20-Poly1305; SHA256 auth; server cert verification; preferred TLS cert profile.
  - Compression disabled; ultra-low logging (verb 0, mute 10).
  - Connection stability: keepalive 10 120, persist-remote-ip, explicit-exit-notify.
  - IPv6 support and leak protection: ifconfig-ipv6, redirect-gateway ipv6, block-ipv6.
  - DNS/routing hardening: configurable DNS (validated IP, default 10.8.0.1), block-outside-dns, redirect-gateway def1.

<sup>Written for commit 2ce9879d551c8c08ce8281af3334903a3f1bb83d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced VPN profile: persistent remote IP, IPv6 interface and routing options, stricter encryption/TLS settings, disabled compression, reduced logging, keepalive, and routing/DNS enhancements (DNS option, block outside DNS, redirect-gateway).
* **New Features**
  * DNS can now be configured via configuration/environment with validation and a sensible default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->