### PR TITLE
chore(deps): apollo 1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/Salvionied/apollo v1.3.0
+	github.com/Salvionied/apollo v1.4.0
 	github.com/SundaeSwap-finance/kugo v1.3.0
 	github.com/SundaeSwap-finance/ogmigo/v6 v6.2.0
 	github.com/aws/aws-sdk-go-v2 v1.40.0
@@ -101,7 +101,6 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,9 @@
-connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
-connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
-github.com/Salvionied/apollo v1.3.0 h1:+FMRnNnee+7dgeEuXfW6emvCNQzeNhytUkcoWM19B2o=
-github.com/Salvionied/apollo v1.3.0/go.mod h1:2C/qJI9NGJ5Z04hoNOAGKelQ1n8DEv3Nv+EVyVfcRwE=
+github.com/Salvionied/apollo v1.4.0 h1:nR4qbpOTvrqCBYQsUQhpNbcSoEnPGF9I2k4EQV7y8Cw=
+github.com/Salvionied/apollo v1.4.0/go.mod h1:VYKmVpsd3WGg+BGEti9s6pLZN4bU0hGjiC5fLtVF6bs=
 github.com/SundaeSwap-finance/kugo v1.3.0 h1:8+c+LJWJ0iByzRJXMMTGtWtsbWQmMIJxBb9mkId9XDU=
 github.com/SundaeSwap-finance/kugo v1.3.0/go.mod h1:NZT9DzTSH8N8IM0Mzn/ISn8xASefO0Xqipw8TGGpMvg=
 github.com/SundaeSwap-finance/ogmigo/v6 v6.2.0 h1:DshTW5GtTzUyktZnHvMLkBzxEVkZzAfG1062cZ455no=
@@ -292,8 +290,6 @@ github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2n
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/utxorpc/go-codegen v0.18.1 h1:2eenzXCkqvB2+g8MCq70MBR6koWs9CeTihZ0AqUvLDY=
 github.com/utxorpc/go-codegen v0.18.1/go.mod h1:DFij3zIGDM39BYCuzrz1rSuO3kTIIiHglWV0043wQxo=
-github.com/utxorpc/go-sdk v0.0.0-20250603130048-8c2c6c6648ea h1:vA8y/BgEIi0m7pXEx9Xbh39IBHqIoyPH3VmpgPwjEgY=
-github.com/utxorpc/go-sdk v0.0.0-20250603130048-8c2c6c6648ea/go.mod h1:nPuFOlAnLsZ9OxGaaSEBJlTVOrJ929PK8EUypTbMZxg=
 github.com/veraison/go-cose v1.3.0 h1:2/H5w8kdSpQJyVtIhx8gmwPJ2uSz1PkyWFx0idbd7rk=
 github.com/veraison/go-cose v1.3.0/go.mod h1:df09OV91aHoQWLmy1KsDdYiagtXgyAwAl8vFeFn1gMc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
@@ -319,8 +315,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/internal/txbuilder/txbuilder.go
+++ b/internal/txbuilder/txbuilder.go
@@ -49,7 +49,7 @@ func apolloBackend() (*OgmiosChainContext.OgmiosChainContext, error) {
 		kugo.WithTimeout(defaultKupoTimeout),
 		kugo.WithLogger(ogmigo.NopLogger),
 	)
-	occ := OgmiosChainContext.NewOgmiosChainContext(*ogmiosClient, *kupoClient)
+	occ := OgmiosChainContext.NewOgmiosChainContext(ogmiosClient, kupoClient)
 	return &occ, nil
 }
 


### PR DESCRIPTION
Closes #219 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded apollo to v1.4.0 and updated txbuilder to match the new OgmiosChainContext constructor. Removed an unused indirect dependency and cleaned up go.sum.

- **Dependencies**
  - Bumped github.com/Salvionied/apollo to v1.4.0.
  - Removed golang.org/x/exp (indirect) and pruned stale go.sum entries.

- **Refactors**
  - Updated NewOgmiosChainContext call to pass client pointers directly (no dereference).

<sup>Written for commit 161fbb46292beb8434c455fca823b259355f3105. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

