### PR TITLE
fix(client): use tls-ciphersuites for tls 1.3

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -45,7 +45,7 @@ block-ipv6
 
 # Encryption and TLS
 cipher AES-256-GCM
-tls-cipher TLS-CHACHA20-POLY1305-SHA256:TLS-AES-256-GCM-SHA384
+tls-ciphersuites TLS-CHACHA20-POLY1305-SHA256:TLS-AES-256-GCM-SHA384
 tls-version-min 1.3
 auth SHA256
 remote-cert-tls server


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the client config to use tls-ciphersuites for TLS 1.3, replacing tls-cipher. This ensures proper cipher selection and prevents TLS 1.3 handshake issues.

<sup>Written for commit dcd40327e6efa15219f13680b875a80a711490d9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TLS cipher configuration in VPN client profiles for improved security standards compliance and enhanced system compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->