### PR TITLE
chore: make format golines

### DIFF
--- a/cmd/vpn-cli/kupo_ref.go
+++ b/cmd/vpn-cli/kupo_ref.go
@@ -137,7 +137,10 @@ func parseHex(s string) string {
 }
 
 // It finds the client UTXO based on script address & fetches its datum & decodes it.
-func findClientOnChain(ctx context.Context, clientIdHex string) (database.Client, error) {
+func findClientOnChain(
+	ctx context.Context,
+	clientIdHex string,
+) (database.Client, error) {
 	cfg := config.GetConfig()
 	if strings.TrimSpace(cfg.Indexer.ScriptAddress) == "" {
 		return database.Client{}, errors.New("script address not configured")
@@ -146,9 +149,14 @@ func findClientOnChain(ctx context.Context, clientIdHex string) (database.Client
 	// script address contains policy id & asset name
 	scriptAddrBytes, err := serAddress.DecodeAddress(cfg.Indexer.ScriptAddress)
 	if err != nil {
-		return database.Client{}, fmt.Errorf("failed in decoding script address: %w", err)
+		return database.Client{}, fmt.Errorf(
+			"failed in decoding script address: %w",
+			err,
+		)
 	}
-	policyHex := strings.ToLower(hex.EncodeToString(scriptAddrBytes.PaymentPart))
+	policyHex := strings.ToLower(
+		hex.EncodeToString(scriptAddrBytes.PaymentPart),
+	)
 	targetAsset := strings.ToLower(parseHex(clientIdHex))
 
 	k, err := getKupoClient()
@@ -160,18 +168,27 @@ func findClientOnChain(ctx context.Context, clientIdHex string) (database.Client
 	assetPattern := fmt.Sprintf("%s.%s", policyHex, targetAsset)
 	matches, err := k.Matches(ctx, kugo.Pattern(assetPattern))
 	if err != nil {
-		return database.Client{}, fmt.Errorf("kupo matches(script address): %w", err)
+		return database.Client{}, fmt.Errorf(
+			"kupo matches(script address): %w",
+			err,
+		)
 	}
 
 	if len(matches) == 0 {
-		return database.Client{}, fmt.Errorf("client not found for clientId=%s", clientIdHex)
+		return database.Client{}, fmt.Errorf(
+			"client not found for clientId=%s",
+			clientIdHex,
+		)
 	}
 
 	// From all UTXOs, pick the one at script address
 	var picked *kugo.Match
 	for i := range matches {
 		m := matches[i]
-		if strings.EqualFold(strings.TrimSpace(m.Address), strings.TrimSpace(cfg.Indexer.ScriptAddress)) {
+		if strings.EqualFold(
+			strings.TrimSpace(m.Address),
+			strings.TrimSpace(cfg.Indexer.ScriptAddress),
+		) {
 			picked = &m
 			break
 		}
@@ -207,7 +224,9 @@ func findClientOnChain(ctx context.Context, clientIdHex string) (database.Client
 	credentialRaw := unwrapAll(fields[0])
 	credential, ok := credentialRaw.([]byte)
 	if !ok || len(credential) == 0 {
-		return database.Client{}, errors.New("invalid credential in client datum")
+		return database.Client{}, errors.New(
+			"invalid credential in client datum",
+		)
 	}
 	region, ok := toString(unwrapAll(fields[1]))
 	if !ok || region == "" {
@@ -215,7 +234,9 @@ func findClientOnChain(ctx context.Context, clientIdHex string) (database.Client
 	}
 	expirationMs, ok := toInt(unwrapAll(fields[2]))
 	if !ok {
-		return database.Client{}, errors.New("invalid expiration in client datum")
+		return database.Client{}, errors.New(
+			"invalid expiration in client datum",
+		)
 	}
 	if credential == nil || region == "" {
 		return database.Client{}, errors.New("invalid fields in client datum")

--- a/cmd/vpn-cli/renew.go
+++ b/cmd/vpn-cli/renew.go
@@ -27,15 +27,20 @@ func init() {
 		RunE:  runRenew,
 	}
 
-	cmd.Flags().StringVar(&flagRenewPayment, "payment", "", "client payment bech32 address (required)")
+	cmd.Flags().
+		StringVar(&flagRenewPayment, "payment", "", "client payment bech32 address (required)")
 	cmd.Flags().StringVar(&flagRenewOwner, "owner", "", "owner bech32 address")
-	cmd.Flags().StringVar(&flagRenewClientID, "client-id", "", "existing client ID (required)")
+	cmd.Flags().
+		StringVar(&flagRenewClientID, "client-id", "", "existing client ID (required)")
 	cmd.Flags().IntVar(&flagRenewPrice, "price", 0, "plan price in lovelace")
-	cmd.Flags().IntVar(&flagRenewDuration, "duration", 0, "plan duration in milliseconds")
+	cmd.Flags().
+		IntVar(&flagRenewDuration, "duration", 0, "plan duration in milliseconds")
 
 	// Load from on chain using Kupo/Ogmios
-	cmd.Flags().StringVar(&flagRenewOgmiosURL, "ogmios-url", "", "Ogmios endpoint (optional)")
-	cmd.Flags().StringVar(&flagRenewKupoURL, "kupo-url", "", "Kupo endpoint (used if --refdata not provided)")
+	cmd.Flags().
+		StringVar(&flagRenewOgmiosURL, "ogmios-url", "", "Ogmios endpoint (optional)")
+	cmd.Flags().
+		StringVar(&flagRenewKupoURL, "kupo-url", "", "Kupo endpoint (used if --refdata not provided)")
 
 	_ = cmd.MarkFlagRequired("payment")
 	_ = cmd.MarkFlagRequired("price")

--- a/cmd/vpn-cli/transfer.go
+++ b/cmd/vpn-cli/transfer.go
@@ -25,13 +25,18 @@ func init() {
 		RunE:  runTransfer,
 	}
 
-	cmd.Flags().StringVar(&flagTransferPayment, "payment", "", "client payment bech32 address (required)")
-	cmd.Flags().StringVar(&flagTransferOwner, "owner", "", "owner bech32 address (required)")
-	cmd.Flags().StringVar(&flagTransferClientID, "client-id", "", "existing client ID (required)")
+	cmd.Flags().
+		StringVar(&flagTransferPayment, "payment", "", "client payment bech32 address (required)")
+	cmd.Flags().
+		StringVar(&flagTransferOwner, "owner", "", "owner bech32 address (required)")
+	cmd.Flags().
+		StringVar(&flagTransferClientID, "client-id", "", "existing client ID (required)")
 
 	// Load from on chain using Kupo/Ogmios
-	cmd.Flags().StringVar(&flagTransferOgmiosURL, "ogmios-url", "", "Ogmios endpoint (optional)")
-	cmd.Flags().StringVar(&flagTransferKupoURL, "kupo-url", "", "Kupo endpoint (used if --refdata not provided)")
+	cmd.Flags().
+		StringVar(&flagTransferOgmiosURL, "ogmios-url", "", "Ogmios endpoint (optional)")
+	cmd.Flags().
+		StringVar(&flagTransferKupoURL, "kupo-url", "", "Kupo endpoint (used if --refdata not provided)")
 
 	_ = cmd.MarkFlagRequired("payment")
 	_ = cmd.MarkFlagRequired("owner")

--- a/internal/txbuilder/renew.go
+++ b/internal/txbuilder/renew.go
@@ -71,7 +71,9 @@ func BuildRenewTransferTx(
 			return nil, fmt.Errorf("lookup client (db): %w", err)
 		}
 	default:
-		return nil, errors.New("renew: deps.Client not provided and no fallback (DB) available")
+		return nil, errors.New(
+			"renew: deps.Client not provided and no fallback (DB) available",
+		)
 	}
 	// Decode payment address
 	paymentAddr, err := serAddress.DecodeAddress(paymentAddress)

--- a/internal/txbuilder/txbuilder.go
+++ b/internal/txbuilder/txbuilder.go
@@ -138,7 +138,9 @@ func chooseInputUtxos(
 	return ret, nil
 }
 
-func clientIdFromInput(input TransactionInput.TransactionInput) ([]byte, error) {
+func clientIdFromInput(
+	input TransactionInput.TransactionInput,
+) ([]byte, error) {
 	tmpData := cbor.NewConstructor(
 		0,
 		cbor.IndefLengthList{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Applied golines formatting across cmd/vpn-cli and internal/txbuilder to wrap long lines and standardize error messages. Improves readability and consistency with no functional or API changes.

<sup>Written for commit bc0c40d5ff8555c32604a5d145f34f937b96b138. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

