### PR TITLE
feat(vpn-indexer): Create binary publishing for vpn-cli

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,20 +68,22 @@ jobs:
       - name: Upload release asset
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          _filename=vpn-indexer-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}
-          if [[ ${{ matrix.os }} == windows ]]; then
-            _filename=${_filename}.exe
-          fi
-          cp vpn-indexer ${_filename}
-          curl \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/octet-stream" \
-            --data-binary @${_filename} \
-            https://uploads.github.com/repos/${{ github.repository_owner }}/vpn-indexer/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}
+          for binary in vpn-indexer vpn-cli; do
+            _filename=${binary}-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}
+            if [[ ${{ matrix.os }} == windows ]]; then
+              _filename=${_filename}.exe
+            fi
+            cp ${binary} ${_filename}
+            curl \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Content-Type: application/octet-stream" \
+              --data-binary @${_filename} \
+              https://uploads.github.com/repos/${{ github.repository_owner }}/vpn-indexer/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}
+          done
       - name: Attest binary
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0 https://github.com/actions/attest-build-provenance/releases/tag/v3.0.0
         with:
-          subject-path: 'vpn-indexer'
+          subject-path: "vpn-*"
 
   build-images:
     needs: [create-draft-release]


### PR DESCRIPTION
1. Modified publish.yaml part to publish binary for vpn-cli as well.

Closes #201 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the release workflow to upload vpn-cli binaries alongside vpn-indexer (including Windows .exe) and attests all vpn-* artifacts. Closes #201.

<sup>Written for commit c2777d558c116aa4dc3289cbcc14e47fbbc766e7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation to build and publish multiple binaries across different platforms and architectures simultaneously, enabling more consistent and efficient distribution of the application across supported operating systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->