### PR TITLE
fix: remove 'block-outside-dns' option from client config

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -63,7 +63,6 @@ keepalive 10 120
 
 # DNS and routing (mirroring server pushes for redundancy)
 dhcp-option DNS %s
-block-outside-dns
 redirect-gateway def1
 
 <cert>


### PR DESCRIPTION
It doesn't work on non-Windows clients

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Windows-only "block-outside-dns" option from the client config to fix errors on Linux and macOS. This improves cross-platform compatibility while keeping DNS settings via dhcp-option.

<sup>Written for commit ad173c8655b4b0cbee03ba378baed9a185cb5e29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted DNS routing configuration in OpenVPN profiles for improved DNS handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->