### PR TITLE
fix: simplify the generated client config to use pushed values

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -39,17 +39,16 @@ remote %s %d
 nobind
 persist-tun
 persist-remote-ip
-ifconfig-ipv6 fd15:53b6:dead:2::2/64 fd15:53b6:dead:2::1
-redirect-gateway ipv6
-block-ipv6
 
 # Encryption and TLS
 cipher AES-256-GCM
-tls-ciphersuites TLS-CHACHA20-POLY1305-SHA256:TLS-AES-256-GCM-SHA384
 tls-version-min 1.3
 auth SHA256
 remote-cert-tls server
-tls-cert-profile preferred
+auth-nocache
+
+# Security hardening
+pull-filter ignore "auth-user-pass"
 
 # Disable compression for privacy
 comp-lzo no
@@ -58,10 +57,7 @@ comp-lzo no
 verb 0
 mute 10
 
-# Connection stability
-keepalive 10 120
-
-# DNS and routing (mirroring server pushes for redundancy)
+# DNS and routing
 dhcp-option DNS %s
 redirect-gateway def1
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified the OpenVPN client config to rely on server-pushed values and remove redundant settings. This reduces conflicts with server pushes and tightens auth handling.

- **Refactors**
  - Removed manual IPv6, keepalive, and TLS ciphersuite/profile lines; rely on server pushes.
  - Kept TLS 1.3 and AES-256-GCM for secure defaults.
  - Streamlined DNS/routing to dhcp-option DNS and redirect-gateway def1.

- **Security**
  - Added auth-nocache to prevent credential storage.
  - Added pull-filter to ignore server-pushed auth-user-pass.

<sup>Written for commit 68c6f9657a5a5a2941ee64c6c9db5a5c6b1297db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced authentication security with updated configuration settings.

* **Bug Fixes**
  * Simplified and streamlined network configuration for improved stability.
  * Removed IPv6 and connection keepalive settings that could cause conflicts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->