### PR TITLE
fix: do not attempt to read nil DB

### DIFF
--- a/internal/txbuilder/renew.go
+++ b/internal/txbuilder/renew.go
@@ -122,10 +122,9 @@ func BuildRenewTransferTx(
 			return nil, fmt.Errorf("reference data: %w", err)
 		}
 	default:
-		refData, err = deps.DB.ReferenceData()
-		if err != nil {
-			return nil, fmt.Errorf("reference data: %w", err)
-		}
+		return nil, errors.New(
+			"renew: deps.Ref not provided and no fallback (DB) available",
+		)
 	}
 	// Parse script ref
 	scriptRef, err := inputRefFromString(cfg.TxBuilder.ScriptRefInput)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent nil pointer crashes in the renew transfer tx builder by removing the DB fallback. If deps.Ref is missing, the function now returns a clear error instead of accessing deps.DB.

<sup>Written for commit 97ab22e71c936e960d2014b060b4ab7bb270422e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

