### PR TITLE
fix: submit failure message shows response

### DIFF
--- a/internal/txbuilder/submit.go
+++ b/internal/txbuilder/submit.go
@@ -16,7 +16,7 @@ package txbuilder
 
 import (
 	"bytes"
-	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -41,17 +41,19 @@ func SubmitTx(txRawBytes []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
-	if resp.Body != nil {
-		_ = resp.Body.Close()
-	}
 	if resp.StatusCode == http.StatusAccepted {
 		return string(respBody), nil
 	}
-	return "", errors.New("empty body returned")
+	return "", fmt.Errorf(
+		"submit failed with status %d: %s",
+		resp.StatusCode,
+		string(respBody),
+	)
 }
 
 // createHTTPClient with custom timeout


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return a clear error from SubmitTx when the node doesn't accept the transaction: include the HTTP status code and response body. Also defer closing the response body to prevent leaks.

<sup>Written for commit 90a98886b023c9034689800325ed5829ee7c6e8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when transaction submissions fail, now displaying HTTP status codes and response details for better debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->