### PR TITLE
fix: ticker leak

### DIFF
--- a/internal/crl/crl.go
+++ b/internal/crl/crl.go
@@ -83,14 +83,10 @@ func (c *Crl) k8sClient() (*kubernetes.Clientset, error) {
 }
 
 func (c *Crl) scheduleUpdateConfigMap() {
-	tickChan := time.Tick(1 * time.Minute)
+	ticker := time.NewTicker(1 * time.Minute)
 	c.nextScheduledUpdate = time.Now().Add(c.config.Crl.UpdateInterval)
 	go func() {
-		for {
-			_, ok := <-tickChan
-			if !ok {
-				return
-			}
+		for range ticker.C {
 			c.needsUpdateMutex.Lock()
 			if time.Now().After(c.nextScheduledUpdate) || c.needsUpdate {
 				if err := c.updateConfigMap(); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced time.Tick with time.NewTicker in the CRL update loop to prevent ticker leaks and allow clean shutdown.

<sup>Written for commit ee91cdb6e6624f8693389b50bd7c12a2f4aeacb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal scheduling logic for improved code maintainability.

---

*Note: This release contains internal improvements with no direct impact to end-user functionality.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->