### PR TITLE
fix: increase estimated script budget for signup

### DIFF
--- a/internal/txbuilder/signup.go
+++ b/internal/txbuilder/signup.go
@@ -197,8 +197,8 @@ func BuildSignupTx(
 		Tag: Redeemer.MINT,
 		// NOTE: these values are estimated
 		ExUnits: Redeemer.ExecutionUnits{
-			Mem:   300_000,
-			Steps: 100_000_000,
+			Mem:   400_000,
+			Steps: 110_000_000,
 		},
 		Data: PlutusData.PlutusData{
 			PlutusDataType: PlutusData.PlutusBytes,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the estimated Plutus script budget for signup minting to reduce validation failures. Memory goes from 300,000 to 400,000 and steps from 100,000,000 to 110,000,000.

<sup>Written for commit 3dbc04f971f023084f1785c3db2697c0e8b915ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource estimates for transaction execution to improve processing reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->