### PR TITLE
fix: use correct subnet mask for Wireguard client configs

### DIFF
--- a/internal/api/wireguard.go
+++ b/internal/api/wireguard.go
@@ -132,7 +132,7 @@ func (r *WGBaseRequest) parseBaseFields() error {
 // WireGuard config template
 const wgConfigTemplate = `[Interface]
 PrivateKey = <REPLACE_WITH_YOUR_PRIVATE_KEY>
-Address = %s/32
+Address = %s/24
 DNS = %s
 
 [Peer]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the correct /24 subnet mask in the WireGuard client config template instead of /32 to match the VPN network and fix routing. This makes generated client configs work out of the box without manual edits.

<sup>Written for commit 2dc28074e4bdb0b5cf58c5a5368448dacbb4f384. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-indexer/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

