### PR TITLE
chore: test and build on Go 1.26

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
       - name: Upload release asset


### PR DESCRIPTION
## Summary

The module already requires Go 1.25 (`go 1.25.8`); this completes the org-wide Go upgrade by also exercising it on **1.26**, matching the rest of the Blink Labs Go repos:

- `go-test.yml`: matrix `[1.25.x]` → `[1.25.x, 1.26.x]`
- `golangci-lint.yml`, `publish.yml`: `1.25.x` → `1.26.x`

`go.mod` is unchanged (already at the 1.25 minimum).

## Verification

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l`, and `golangci-lint run ./...` (0 issues) all pass locally on Go 1.26.

Part of the org-wide Go 1.25 upgrade (blinklabs-io/issues#120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Test and build on Go 1.26 in CI while keeping the module’s minimum at Go 1.25. Adds 1.26.x to `go-test.yml` and updates `golangci-lint.yml` and `publish.yml` to run on 1.26.x; `go.mod` is unchanged.

<sup>Written for commit 80a7ee32e98bfc200dcc2e26bba8bed3afb59e82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-indexer/pull/359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated toolchain to Go 1.26.x across testing and build pipelines for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->