### PR TITLE
feat: use session token for API auth

### DIFF
--- a/cmd/vpn-indexer/main.go
+++ b/cmd/vpn-indexer/main.go
@@ -157,6 +157,19 @@ func main() {
 	var crlInstance *crl.Crl
 	var wgClient *wireguard.Client
 	var s3Client *client.Client
+	var jwtIssuer *jwt.Issuer
+
+	// Initialize the JWT issuer up front: it signs browser session tokens for
+	// every protocol (so /api/auth/session is available regardless of protocol)
+	// and also authenticates the indexer to the WireGuard container. The key
+	// file config (VPN_JWT_KEY_FILE) is required for all protocols.
+	jwtIssuer, err = jwt.NewIssuer(cfg.Vpn.JWTKeyFile)
+	if err != nil {
+		slog.Error(
+			fmt.Sprintf("failed to initialize JWT issuer: %s", err),
+		)
+		os.Exit(1)
+	}
 
 	switch cfg.Vpn.Protocol {
 	case "openvpn":
@@ -180,15 +193,6 @@ func main() {
 	case "wireguard":
 		// Initialize WireGuard components if protocol is wireguard
 		slog.Info("initializing WireGuard components")
-
-		// Initialize JWT issuer for WG container authentication
-		jwtIssuer, err := jwt.NewIssuer(cfg.Vpn.WGJWTKeyFile)
-		if err != nil {
-			slog.Error(
-				fmt.Sprintf("failed to initialize JWT issuer: %s", err),
-			)
-			os.Exit(1)
-		}
 
 		// Initialize WG container client
 		wgClient = wireguard.NewClient(cfg.Vpn.WGContainerURL, jwtIssuer)
@@ -252,7 +256,7 @@ func main() {
 	}
 
 	// Start API listener
-	if err := api.Start(cfg, db, caInstance, wgClient, s3Client); err != nil {
+	if err := api.Start(cfg, db, caInstance, wgClient, s3Client, jwtIssuer); err != nil {
 		slog.Error(
 			"failed to start API:",
 			"error",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -23,6 +23,67 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/auth/session": {
+            "post": {
+                "description": "Exchange a wallet-signed challenge for a short-lived session token covering all of the wallet's subscriptions",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "AuthSession",
+                "parameters": [
+                    {
+                        "description": "Session Request",
+                        "name": "SessionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.SessionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Session token",
+                        "schema": {
+                            "$ref": "#/definitions/api.SessionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden (no subscriptions for wallet)",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/client/available": {
             "post": {
                 "description": "Check if a client profile is available",
@@ -123,7 +184,12 @@ const docTemplate = `{
         },
         "/api/client/profile": {
             "post": {
-                "description": "Fetch a client VPN profile given a COSE payload via signed S3 link",
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Fetch a client VPN profile via a signed S3 link; authenticate with a session Bearer token and provide the subscription id in the body",
                 "consumes": [
                     "application/json"
                 ],
@@ -152,6 +218,18 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "405": {
                         "description": "Method Not Allowed",
                         "schema": {
@@ -169,6 +247,11 @@ const docTemplate = `{
         },
         "/api/client/wg-devices": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "List all WireGuard devices registered for a client",
                 "consumes": [
                     "application/json"
@@ -224,6 +307,11 @@ const docTemplate = `{
         },
         "/api/client/wg-peer": {
             "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Remove a WireGuard device registration",
                 "consumes": [
                     "application/json"
@@ -291,6 +379,11 @@ const docTemplate = `{
         },
         "/api/client/wg-profile": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Get a WireGuard configuration profile for a registered device",
                 "consumes": [
                     "application/json"
@@ -359,6 +452,11 @@ const docTemplate = `{
         },
         "/api/client/wg-register": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Register a new WireGuard device for a client",
                 "consumes": [
                     "application/json"
@@ -690,12 +788,6 @@ const docTemplate = `{
             "properties": {
                 "id": {
                     "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
                 }
             }
         },
@@ -735,6 +827,32 @@ const docTemplate = `{
                 },
                 "price": {
                     "type": "integer"
+                }
+            }
+        },
+        "api.SessionRequest": {
+            "type": "object",
+            "required": [
+                "key",
+                "signature"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "signature": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.SessionResponse": {
+            "type": "object",
+            "properties": {
+                "expires_at": {
+                    "type": "integer"
+                },
+                "token": {
+                    "type": "string"
                 }
             }
         },
@@ -825,12 +943,6 @@ const docTemplate = `{
                 "client_id": {
                     "type": "string"
                 },
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
-                },
                 "wg_pubkey": {
                     "type": "string"
                 }
@@ -866,12 +978,6 @@ const docTemplate = `{
             "properties": {
                 "client_id": {
                     "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
                 }
             }
         },
@@ -895,12 +1001,6 @@ const docTemplate = `{
                 "client_id": {
                     "type": "string"
                 },
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
-                },
                 "wg_pubkey": {
                     "type": "string"
                 }
@@ -910,12 +1010,6 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "client_id": {
-                    "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
                     "type": "string"
                 },
                 "wg_pubkey": {
@@ -939,6 +1033,14 @@ const docTemplate = `{
                     "type": "boolean"
                 }
             }
+        }
+    },
+    "securityDefinitions": {
+        "BearerAuth": {
+            "description": "Session token from POST /api/auth/session, sent as \"Bearer \u003ctoken\u003e\".",
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
         }
     }
 }`

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -16,6 +16,67 @@
     },
     "basePath": "/",
     "paths": {
+        "/api/auth/session": {
+            "post": {
+                "description": "Exchange a wallet-signed challenge for a short-lived session token covering all of the wallet's subscriptions",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "AuthSession",
+                "parameters": [
+                    {
+                        "description": "Session Request",
+                        "name": "SessionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.SessionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Session token",
+                        "schema": {
+                            "$ref": "#/definitions/api.SessionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden (no subscriptions for wallet)",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/client/available": {
             "post": {
                 "description": "Check if a client profile is available",
@@ -116,7 +177,12 @@
         },
         "/api/client/profile": {
             "post": {
-                "description": "Fetch a client VPN profile given a COSE payload via signed S3 link",
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Fetch a client VPN profile via a signed S3 link; authenticate with a session Bearer token and provide the subscription id in the body",
                 "consumes": [
                     "application/json"
                 ],
@@ -145,6 +211,18 @@
                             "type": "string"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "405": {
                         "description": "Method Not Allowed",
                         "schema": {
@@ -162,6 +240,11 @@
         },
         "/api/client/wg-devices": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "List all WireGuard devices registered for a client",
                 "consumes": [
                     "application/json"
@@ -217,6 +300,11 @@
         },
         "/api/client/wg-peer": {
             "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Remove a WireGuard device registration",
                 "consumes": [
                     "application/json"
@@ -284,6 +372,11 @@
         },
         "/api/client/wg-profile": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Get a WireGuard configuration profile for a registered device",
                 "consumes": [
                     "application/json"
@@ -352,6 +445,11 @@
         },
         "/api/client/wg-register": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Register a new WireGuard device for a client",
                 "consumes": [
                     "application/json"
@@ -683,12 +781,6 @@
             "properties": {
                 "id": {
                     "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
                 }
             }
         },
@@ -728,6 +820,32 @@
                 },
                 "price": {
                     "type": "integer"
+                }
+            }
+        },
+        "api.SessionRequest": {
+            "type": "object",
+            "required": [
+                "key",
+                "signature"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "signature": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.SessionResponse": {
+            "type": "object",
+            "properties": {
+                "expires_at": {
+                    "type": "integer"
+                },
+                "token": {
+                    "type": "string"
                 }
             }
         },
@@ -818,12 +936,6 @@
                 "client_id": {
                     "type": "string"
                 },
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
-                },
                 "wg_pubkey": {
                     "type": "string"
                 }
@@ -859,12 +971,6 @@
             "properties": {
                 "client_id": {
                     "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
                 }
             }
         },
@@ -888,12 +994,6 @@
                 "client_id": {
                     "type": "string"
                 },
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
-                },
                 "wg_pubkey": {
                     "type": "string"
                 }
@@ -903,12 +1003,6 @@
             "type": "object",
             "properties": {
                 "client_id": {
-                    "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
                     "type": "string"
                 },
                 "wg_pubkey": {
@@ -932,6 +1026,14 @@
                     "type": "boolean"
                 }
             }
+        }
+    },
+    "securityDefinitions": {
+        "BearerAuth": {
+            "description": "Session token from POST /api/auth/session, sent as \"Bearer \u003ctoken\u003e\".",
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
         }
     }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -23,10 +23,6 @@ definitions:
     properties:
       id:
         type: string
-      key:
-        type: string
-      signature:
-        type: string
     type: object
   api.ErrorResponse:
     properties:
@@ -52,6 +48,23 @@ definitions:
         type: integer
       price:
         type: integer
+    type: object
+  api.SessionRequest:
+    properties:
+      key:
+        type: string
+      signature:
+        type: string
+    required:
+    - key
+    - signature
+    type: object
+  api.SessionResponse:
+    properties:
+      expires_at:
+        type: integer
+      token:
+        type: string
     type: object
   api.TxRenewRequest:
     properties:
@@ -109,10 +122,6 @@ definitions:
     properties:
       client_id:
         type: string
-      key:
-        type: string
-      signature:
-        type: string
       wg_pubkey:
         type: string
     type: object
@@ -136,10 +145,6 @@ definitions:
     properties:
       client_id:
         type: string
-      key:
-        type: string
-      signature:
-        type: string
     type: object
   api.WGDevicesResponse:
     properties:
@@ -154,20 +159,12 @@ definitions:
     properties:
       client_id:
         type: string
-      key:
-        type: string
-      signature:
-        type: string
       wg_pubkey:
         type: string
     type: object
   api.WGRegisterRequest:
     properties:
       client_id:
-        type: string
-      key:
-        type: string
-      signature:
         type: string
       wg_pubkey:
         type: string
@@ -195,6 +192,47 @@ info:
   title: vpn-indexer
   version: v0
 paths:
+  /api/auth/session:
+    post:
+      consumes:
+      - application/json
+      description: Exchange a wallet-signed challenge for a short-lived session token
+        covering all of the wallet's subscriptions
+      parameters:
+      - description: Session Request
+        in: body
+        name: SessionRequest
+        required: true
+        schema:
+          $ref: '#/definitions/api.SessionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Session token
+          schema:
+            $ref: '#/definitions/api.SessionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "403":
+          description: Forbidden (no subscriptions for wallet)
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            type: string
+        "500":
+          description: Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      summary: AuthSession
   /api/client/available:
     post:
       consumes:
@@ -263,7 +301,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Fetch a client VPN profile given a COSE payload via signed S3 link
+      description: Fetch a client VPN profile via a signed S3 link; authenticate with
+        a session Bearer token and provide the subscription id in the body
       parameters:
       - description: Profile Request
         in: body
@@ -280,6 +319,14 @@ paths:
           description: Bad Request
           schema:
             type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "403":
+          description: Forbidden
+          schema:
+            type: string
         "405":
           description: Method Not Allowed
           schema:
@@ -288,6 +335,8 @@ paths:
           description: Server Error
           schema:
             type: string
+      security:
+      - BearerAuth: []
       summary: ClientProfile
   /api/client/wg-devices:
     post:
@@ -324,6 +373,8 @@ paths:
           description: Server Error
           schema:
             $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - BearerAuth: []
       summary: WGDevices
   /api/client/wg-peer:
     delete:
@@ -368,6 +419,8 @@ paths:
           description: Server Error
           schema:
             $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - BearerAuth: []
       summary: WGPeerDelete
   /api/client/wg-profile:
     post:
@@ -413,6 +466,8 @@ paths:
           description: Server Error
           schema:
             $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - BearerAuth: []
       summary: WGProfile
   /api/client/wg-register:
     post:
@@ -454,6 +509,8 @@ paths:
           description: Server Error
           schema:
             $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - BearerAuth: []
       summary: WGRegister
   /api/refdata:
     get:
@@ -609,4 +666,10 @@ paths:
           schema:
             type: string
       summary: TxTransfer
+securityDefinitions:
+  BearerAuth:
+    description: Session token from POST /api/auth/session, sent as "Bearer <token>".
+    in: header
+    name: Authorization
+    type: apiKey
 swagger: "2.0"

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/vpn-indexer/internal/client"
 	"github.com/blinklabs-io/vpn-indexer/internal/config"
 	"github.com/blinklabs-io/vpn-indexer/internal/database"
+	"github.com/blinklabs-io/vpn-indexer/internal/jwt"
 	"github.com/blinklabs-io/vpn-indexer/internal/wireguard"
 	httpSwagger "github.com/swaggo/http-swagger"
 )
@@ -35,39 +36,54 @@ const (
 
 // Api holds the dependencies for the API server.
 type Api struct {
-	cfg      *config.Config
-	db       *database.Database
-	ca       *ca.Ca
-	wgClient *wireguard.Client
-	s3Client *client.Client
+	cfg       *config.Config
+	db        *database.Database
+	ca        *ca.Ca
+	wgClient  *wireguard.Client
+	s3Client  *client.Client
+	jwtIssuer *jwt.Issuer
 }
 
-// @title			vpn-indexer
-// @version		v0
-// @description	NABU VPN indexer API
-// @BasePath		/
-// @contact.name	Blink Labs Software
-// @contact.url	https://blinklabs.io
-// @contact.email	support@blinklabs.io
+// @title						vpn-indexer
+// @version					v0
+// @description				NABU VPN indexer API
+// @BasePath					/
+// @contact.name				Blink Labs Software
+// @contact.url				https://blinklabs.io
+// @contact.email				support@blinklabs.io
 //
-// @license.name	Apache 2.0
-// @license.url	http://www.apache.org/licenses/LICENSE-2.0.html
+// @license.name				Apache 2.0
+// @license.url				http://www.apache.org/licenses/LICENSE-2.0.html
+//
+// @securityDefinitions.apikey	BearerAuth
+// @in							header
+// @name						Authorization
+// @description				Session token from POST /api/auth/session, sent as "Bearer <token>".
 func Start(
 	cfg *config.Config,
 	db *database.Database,
 	ca *ca.Ca,
 	wgClient *wireguard.Client,
 	s3Client *client.Client,
+	jwtIssuer *jwt.Issuer,
 ) error {
 	logger := slog.Default()
 	logger.Info("initializing API server")
 
+	// The JWT issuer is required: the session auth route and every
+	// session-protected handler dereference it. Fail fast rather than register
+	// handlers that would panic at request time.
+	if jwtIssuer == nil {
+		return fmt.Errorf("jwtIssuer is required")
+	}
+
 	api := &Api{
-		cfg:      cfg,
-		db:       db,
-		ca:       ca,
-		wgClient: wgClient,
-		s3Client: s3Client,
+		cfg:       cfg,
+		db:        db,
+		ca:        ca,
+		wgClient:  wgClient,
+		s3Client:  s3Client,
+		jwtIssuer: jwtIssuer,
 	}
 
 	//
@@ -90,6 +106,10 @@ func Start(
 	mainMux.HandleFunc("/api/tx/renew", api.handleTxRenew)
 	mainMux.HandleFunc("/api/tx/transfer", api.handleTxTransfer)
 	mainMux.HandleFunc("/api/tx/submit", api.handleTxSubmit)
+
+	// Session auth route. The JWT issuer is required for all protocols, so this
+	// is always available.
+	mainMux.HandleFunc("/api/auth/session", api.handleAuthSession)
 
 	// WireGuard API routes (only register when both wgClient and s3Client are available)
 	if api.wgClient != nil && api.s3Client != nil {

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,0 +1,382 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/vpn-indexer/internal/database"
+	"github.com/veraison/go-cose"
+)
+
+// SessionRequest is the request body for POST /api/auth/session. It carries a
+// wallet-signed challenge; the issued token is scoped to the wallet credential
+// derived from the signing key.
+type SessionRequest struct {
+	Signature string `json:"signature" binding:"required"`
+	Key       string `json:"key"       binding:"required"`
+
+	// Parsed representations (not serialized).
+	innerSignature cose.UntaggedSign1Message
+	innerKey       cose.Key
+}
+
+func (r *SessionRequest) UnmarshalJSON(data []byte) error {
+	type alias SessionRequest
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	*r = SessionRequest(tmp)
+
+	// Decode the signature and key from the challenge.
+	var err error
+	r.innerSignature, r.innerKey, err = parseCOSESignature(r.Signature, r.Key)
+	return err
+}
+
+// parseCOSESignature decodes the hex-encoded COSE signature and key from a
+// session challenge request. Either may be empty, in which case the zero value
+// is returned for it.
+func parseCOSESignature(
+	signature, key string,
+) (cose.UntaggedSign1Message, cose.Key, error) {
+	var (
+		innerSignature cose.UntaggedSign1Message
+		innerKey       cose.Key
+	)
+	if signature != "" {
+		sigBytes, err := hex.DecodeString(signature)
+		if err != nil {
+			return innerSignature, innerKey, fmt.Errorf(
+				"decode signature hex: %w", err,
+			)
+		}
+		if err := innerSignature.UnmarshalCBOR(sigBytes); err != nil {
+			return innerSignature, innerKey, fmt.Errorf(
+				"decode signature: %w", err,
+			)
+		}
+	}
+	if key != "" {
+		keyBytes, err := hex.DecodeString(key)
+		if err != nil {
+			return innerSignature, innerKey, fmt.Errorf(
+				"decode key hex: %w", err,
+			)
+		}
+		if err := innerKey.UnmarshalCBOR(keyBytes); err != nil {
+			return innerSignature, innerKey, fmt.Errorf("decode key: %w", err)
+		}
+	}
+	return innerSignature, innerKey, nil
+}
+
+// sessionChallengePrefix identifies the session challenge payload, separating
+// it from any other signed material a wallet might produce.
+const sessionChallengePrefix = "vpn-session:"
+
+// validateChallengeTimestamp checks that a unix-timestamp string falls within
+// the accepted freshness window.
+//
+// Because the service stores no nonces, this window is the sole replay
+// defence: a captured signed challenge is replayable only until its timestamp
+// ages out. The small future-skew allowance tolerates clock drift.
+func validateChallengeTimestamp(ts string) error {
+	tmpTimestamp, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil {
+		return errors.New(
+			"could not extract timestamp from challenge string",
+		)
+	}
+	age := time.Since(time.Unix(tmpTimestamp, 0))
+	// Reject timestamps too far in the future (negative age beyond the skew
+	// window) to prevent replay attacks while allowing small clock differences.
+	if age < -TimestampFutureSkewWindow {
+		return errors.New(
+			"challenge string timestamp is too far in the future",
+		)
+	}
+	if age > TimestampValidityWindow {
+		return errors.New("challenge string timestamp is too old")
+	}
+	return nil
+}
+
+// validateSessionChallenge verifies that a COSE payload of the form
+// "vpn-session:<unixTimestamp>" carries a fresh timestamp.
+func validateSessionChallenge(payload []byte) error {
+	s := string(payload)
+	if !strings.HasPrefix(s, sessionChallengePrefix) {
+		return errors.New("invalid session challenge")
+	}
+	return validateChallengeTimestamp(s[len(sessionChallengePrefix):])
+}
+
+// verifySessionChallenge verifies a wallet-signed session challenge and returns
+// the credential (Blake2b-224 hash of the signing key, i.e. the payment key
+// hash) it resolves to. This credential is the identity a session token is
+// bound to; it covers every subscription owned by that credential.
+func (a *Api) verifySessionChallenge(
+	innerSignature *cose.UntaggedSign1Message,
+	innerKey *cose.Key,
+) ([]byte, error) {
+	if err := validateSessionChallenge(innerSignature.Payload); err != nil {
+		return nil, err
+	}
+
+	vkey, err := innerKey.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get public key: %w", err)
+	}
+	verifier, err := cose.NewVerifier(cose.AlgorithmEdDSA, vkey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create verifier: %w", err)
+	}
+	if err := innerSignature.Verify(nil, verifier); err != nil {
+		return nil, errors.New("failed to validate signature")
+	}
+
+	ed25519Key, ok := vkey.(ed25519.PublicKey)
+	if !ok {
+		return nil, errors.New("public key is not Ed25519")
+	}
+	return lcommon.Blake2b224Hash([]byte(ed25519Key)).Bytes(), nil
+}
+
+// SessionResponse is the response from POST /api/auth/session.
+type SessionResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expires_at"`
+}
+
+// handleAuthSession handles POST /api/auth/session
+//
+//	@Summary		AuthSession
+//	@Description	Exchange a wallet-signed challenge for a short-lived session token covering all of the wallet's subscriptions
+//	@Accept			json
+//	@Produce		json
+//	@Param			SessionRequest	body		SessionRequest	true	"Session Request"
+//	@Success		200				{object}	SessionResponse	"Session token"
+//	@Failure		400				{object}	ErrorResponse	"Bad Request"
+//	@Failure		401				{object}	ErrorResponse	"Unauthorized"
+//	@Failure		403				{object}	ErrorResponse	"Forbidden (no subscriptions for wallet)"
+//	@Failure		405				{object}	string			"Method Not Allowed"
+//	@Failure		500				{object}	ErrorResponse	"Server Error"
+//	@Router			/api/auth/session [post]
+func (a *Api) handleAuthSession(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req SessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		slog.Debug("failed to decode session request", "error", err)
+		writeErrorResponse(
+			w,
+			http.StatusBadRequest,
+			"Invalid request",
+			"malformed request body",
+		)
+		return
+	}
+
+	// A session is established with a fresh wallet signature; the token is
+	// bound to the wallet credential derived from the signing key.
+	if req.Signature == "" || req.Key == "" {
+		writeErrorResponse(
+			w,
+			http.StatusBadRequest,
+			"Invalid request",
+			"signature and key are required",
+		)
+		return
+	}
+
+	// Verify the signed challenge and derive the wallet credential.
+	credential, err := a.verifySessionChallenge(
+		&req.innerSignature,
+		&req.innerKey,
+	)
+	if err != nil {
+		slog.Error("session challenge verification failed", "error", err)
+		writeErrorResponse(
+			w,
+			http.StatusUnauthorized,
+			"Unauthorized",
+			"signature verification failed",
+		)
+		return
+	}
+
+	// The credential must own at least one subscription: this rejects keys
+	// unrelated to any subscription and confirms the wallet is known.
+	clients, err := a.db.ClientsByCredential(credential)
+	if err != nil {
+		slog.Error("failed to lookup clients by credential", "error", err)
+		writeErrorResponse(
+			w,
+			http.StatusInternalServerError,
+			"Internal server error",
+			"",
+		)
+		return
+	}
+	if len(clients) == 0 {
+		writeErrorResponse(
+			w,
+			http.StatusForbidden,
+			"Forbidden",
+			"no subscriptions for this wallet",
+		)
+		return
+	}
+
+	token, expiresAt, err := a.jwtIssuer.IssueSessionJWT(
+		hex.EncodeToString(credential),
+	)
+	if err != nil {
+		slog.Error("failed to issue session token", "error", err)
+		writeErrorResponse(
+			w,
+			http.StatusInternalServerError,
+			"Internal server error",
+			"",
+		)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	// The response carries a bearer credential; never let it be cached.
+	w.Header().Set("Cache-Control", "no-store")
+	resp := SessionResponse{
+		Token:     token,
+		ExpiresAt: expiresAt.Unix(),
+	}
+	respBytes, _ := json.Marshal(resp)
+	_, _ = w.Write(respBytes)
+}
+
+// bearerToken extracts a Bearer token from the Authorization header.
+// Returns an empty string when no Bearer token is present.
+func bearerToken(r *http.Request) string {
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if len(h) > len(prefix) && strings.EqualFold(h[:len(prefix)], prefix) {
+		return strings.TrimSpace(h[len(prefix):])
+	}
+	return ""
+}
+
+// sessionCredential resolves the wallet credential carried by a Bearer session
+// token.
+//
+// present is false when no Bearer token is sent. When a token is present but
+// invalid the bool is true and err is non-nil. The returned credential
+// authorises any subscription whose Client.Credential matches it.
+func (a *Api) sessionCredential(
+	r *http.Request,
+) (credential []byte, present bool, err error) {
+	token := bearerToken(r)
+	if token == "" {
+		return nil, false, nil
+	}
+	credentialHex, err := a.jwtIssuer.VerifySessionJWT(token)
+	if err != nil {
+		return nil, true, fmt.Errorf("invalid session token: %w", err)
+	}
+	credential, err = hex.DecodeString(credentialHex)
+	if err != nil {
+		return nil, true, errors.New("invalid credential in session token")
+	}
+	return credential, true, nil
+}
+
+// authorizeClient confirms the named subscription belongs to the wallet
+// credential and returns it. Identity (the credential) comes from the token;
+// the body only names which subscription to act on, so the ownership check is
+// what prevents a token from acting on another wallet's subscription.
+func (a *Api) authorizeClient(
+	credential []byte,
+	innerClientID []byte,
+) (*database.Client, error) {
+	if len(innerClientID) == 0 {
+		return nil, errors.New("client_id is required")
+	}
+	tmpClient, err := a.db.ClientByAssetName(innerClientID)
+	if err != nil {
+		// A missing record is an auth/ownership failure; any other error is an
+		// infrastructure problem that must surface as 500, not 401.
+		if errors.Is(err, database.ErrRecordNotFound) {
+			return nil, errors.New("session token does not own this subscription")
+		}
+		return nil, fmt.Errorf("%w: lookup client: %w", errAuthInternal, err)
+	}
+	if !bytes.Equal(tmpClient.Credential, credential) {
+		return nil, errors.New("session token does not own this subscription")
+	}
+	return &tmpClient, nil
+}
+
+// errAuthInternal wraps an internal failure (e.g. a database error) that occurs
+// while authenticating a request, so handlers can return 500 rather than
+// masking infrastructure problems as 401 Unauthorized.
+var errAuthInternal = errors.New("internal authentication error")
+
+// writeAuthError maps an authenticate() error to an HTTP response: internal
+// failures return 500, all other (invalid token / ownership) failures return
+// 401.
+func (a *Api) writeAuthError(w http.ResponseWriter, err error) {
+	if errors.Is(err, errAuthInternal) {
+		slog.Error("authentication error", "error", err)
+		writeErrorResponse(
+			w, http.StatusInternalServerError, "Internal server error", "",
+		)
+		return
+	}
+	slog.Warn("authentication failed", "error", err)
+	writeErrorResponse(
+		w, http.StatusUnauthorized, "Unauthorized", "authentication failed",
+	)
+}
+
+// authenticate resolves and authorizes the client for a protected request. It
+// requires a valid Bearer session token and confirms the named subscription
+// (innerClientID) belongs to the token's wallet credential.
+func (a *Api) authenticate(
+	r *http.Request,
+	innerClientID []byte,
+) (*database.Client, error) {
+	credential, present, err := a.sessionCredential(r)
+	if !present {
+		return nil, errors.New("session token required")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return a.authorizeClient(credential, innerClientID)
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -15,21 +15,16 @@
 package api
 
 import (
-	"crypto/ed25519"
-	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"time"
 
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/vpn-indexer/internal/client"
 	"github.com/blinklabs-io/vpn-indexer/internal/database"
-	"github.com/veraison/go-cose"
 )
 
 // ClientListRequest provides the payment credential hash to search
@@ -111,15 +106,12 @@ func (a *Api) handleClientList(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(resp)
 }
 
-// ClientProfileRequest provides the client ID and COSE payload for verification
+// ClientProfileRequest names the target subscription; auth is via the session token
 type ClientProfileRequest struct {
-	Id        string `json:"id"`
-	Signature string `json:"signature"`
-	Key       string `json:"key"`
-	// Inner representations
-	innerId        []byte
-	innerSignature cose.UntaggedSign1Message
-	innerKey       cose.Key
+	Id string `json:"id"`
+	// Inner representation (not serialized). Authentication is via a Bearer
+	// session token; id only names the target subscription.
+	innerId []byte
 }
 
 func (r *ClientProfileRequest) UnmarshalJSON(data []byte) error {
@@ -128,45 +120,28 @@ func (r *ClientProfileRequest) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &tmpData); err != nil {
 		return err
 	}
-	// Copy original request data
 	r.Id = tmpData.Id
-	r.Signature = tmpData.Signature
-	r.Key = tmpData.Key
-	// Client ID
-	tmpId, err := hex.DecodeString(tmpData.Id)
+	id, err := hex.DecodeString(r.Id)
 	if err != nil {
 		return errors.New("decode client ID hex")
 	}
-	r.innerId = tmpId
-	// Signature
-	sigBytes, err := hex.DecodeString(tmpData.Signature)
-	if err != nil {
-		return errors.New("decode signature hex")
-	}
-	if err := r.innerSignature.UnmarshalCBOR(sigBytes); err != nil {
-		return fmt.Errorf("decode signature: %w", err)
-	}
-	// Key
-	keyBytes, err := hex.DecodeString(tmpData.Key)
-	if err != nil {
-		return errors.New("decode key hex")
-	}
-	if err := r.innerKey.UnmarshalCBOR(keyBytes); err != nil {
-		return fmt.Errorf("decode key: %w", err)
-	}
+	r.innerId = id
 	return nil
 }
 
 // handleClientProfile godoc
 //
 //	@Summary		ClientProfile
-//	@Description	Fetch a client VPN profile given a COSE payload via signed S3 link
+//	@Description	Fetch a client VPN profile via a signed S3 link; authenticate with a session Bearer token and provide the subscription id in the body
 //	@Accept			json
 //	@Param			ClientProfileRequest	body		ClientProfileRequest	true	"Profile Request"
 //	@Success		302						{string}	string					"Found"
 //	@Failure		400						{object}	string					"Bad Request"
+//	@Failure		401						{object}	string					"Unauthorized"
+//	@Failure		403						{object}	string					"Forbidden"
 //	@Failure		405						{object}	string					"Method Not Allowed"
 //	@Failure		500						{object}	string					"Server Error"
+//	@Security		BearerAuth
 //	@Router			/api/client/profile [post]
 func (a *Api) handleClientProfile(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -183,16 +158,20 @@ func (a *Api) handleClientProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Lookup client in database
-	tmpClient, err := a.db.ClientByAssetName(req.innerId)
+	// Authenticate via the Bearer session token and authorise the requested
+	// subscription against the token's wallet credential.
+	tmpClient, err := a.authenticate(r, req.innerId)
 	if err != nil {
-		slog.Error(
-			"failed to lookup client in database",
-			"error",
-			err,
+		a.writeAuthError(w, err)
+		return
+	}
+
+	// Reject expired subscriptions, as the WireGuard handlers do.
+	if time.Now().After(tmpClient.Expiration) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write(
+			[]byte(`{"error":"Forbidden","reason":"subscription has expired"}`),
 		)
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error":"Internal server error"}`))
 		return
 	}
 
@@ -210,91 +189,6 @@ func (a *Api) handleClientProfile(w http.ResponseWriter, r *http.Request) {
 	} else if !ok {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(`{"error":"Not found","reason":"client profile doesn't exist"}`))
-		return
-	}
-
-	// Verify challenge string meets requirements
-	challengeClientId := string(
-		req.innerSignature.Payload[0:len(req.Id)],
-	)
-	if challengeClientId != req.Id {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write(
-			[]byte(
-				`{"error":"Invalid request","reason":"challenge string does not match client ID"}`,
-			),
-		)
-		return
-	}
-	challengeTimestamp := string(
-		req.innerSignature.Payload[len(challengeClientId):],
-	)
-	tmpTimestamp, err := strconv.ParseInt(challengeTimestamp, 10, 64)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write(
-			[]byte(
-				`{"error":"Invalid request","reason":"could not extract timestamp from challenge string"}`,
-			),
-		)
-		return
-	}
-	timestamp := time.Unix(tmpTimestamp, 0)
-	if time.Since(timestamp) > (15 * time.Minute) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write(
-			[]byte(
-				`{"error":"Invalid request","reason":"challenge string timestamp is too old"}`,
-			),
-		)
-		return
-	}
-
-	// Verify challenge signature
-	vkey, err := req.innerKey.PublicKey()
-	if err != nil {
-		slog.Error(
-			"failed to get public key",
-			"error",
-			err,
-		)
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error":"Internal server error"}`))
-		return
-	}
-	verifier, err := cose.NewVerifier(cose.AlgorithmEdDSA, vkey)
-	if err != nil {
-		slog.Error(
-			"failed to create verifier",
-			"error",
-			err,
-		)
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error":"Internal server error"}`))
-		return
-	}
-	if err := req.innerSignature.Verify(nil, verifier); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write(
-			[]byte(
-				`{"error":"Invalid request","reason":"failed to validate signature"}`,
-			),
-		)
-		return
-	}
-	// Check that signing key matches known client credential
-	vkeyHash := lcommon.Blake2b224Hash(
-		[]byte(
-			vkey.(ed25519.PublicKey),
-		),
-	)
-	if subtle.ConstantTimeCompare(vkeyHash.Bytes(), tmpClient.Credential) != 1 {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write(
-			[]byte(
-				`{"error":"Invalid request","reason":"key hash does not match credential for client"}`,
-			),
-		)
 		return
 	}
 

--- a/internal/api/wireguard.go
+++ b/internal/api/wireguard.go
@@ -16,8 +16,6 @@ package api
 
 import (
 	"context"
-	"crypto/ed25519"
-	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -25,14 +23,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"time"
 
-	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/vpn-indexer/internal/client"
 	"github.com/blinklabs-io/vpn-indexer/internal/database"
 	"github.com/blinklabs-io/vpn-indexer/internal/wireguard"
-	"github.com/veraison/go-cose"
 )
 
 const (
@@ -87,45 +82,22 @@ func isValidWGPubkey(pubkey string) bool {
 
 // WGBaseRequest contains the common fields for all WireGuard API requests.
 // This is embedded by specific request types that may add additional fields.
-// Note: Timestamp validation uses the timestamp embedded in the COSE signature
-// payload (clientID + timestamp), not a separate JSON field.
+// Requests are authenticated with a Bearer session token; client_id only names
+// the target subscription.
 type WGBaseRequest struct {
-	ClientID  string `json:"client_id"`
-	Signature string `json:"signature"`
-	Key       string `json:"key"`
-	// Parsed representations (not serialized)
-	innerClientID  []byte
-	innerSignature cose.UntaggedSign1Message
-	innerKey       cose.Key
+	ClientID string `json:"client_id"`
+	// Parsed representation (not serialized)
+	innerClientID []byte
 }
 
-// parseBaseFields parses and validates the hex-encoded fields
+// parseBaseFields decodes the hex-encoded client ID that names the target
+// subscription.
 func (r *WGBaseRequest) parseBaseFields() error {
-	// Client ID
-	tmpId, err := hex.DecodeString(r.ClientID)
+	id, err := hex.DecodeString(r.ClientID)
 	if err != nil {
 		return errors.New("decode client ID hex")
 	}
-	r.innerClientID = tmpId
-
-	// Signature
-	sigBytes, err := hex.DecodeString(r.Signature)
-	if err != nil {
-		return errors.New("decode signature hex")
-	}
-	if err := r.innerSignature.UnmarshalCBOR(sigBytes); err != nil {
-		return fmt.Errorf("decode signature: %w", err)
-	}
-
-	// Key
-	keyBytes, err := hex.DecodeString(r.Key)
-	if err != nil {
-		return errors.New("decode key hex")
-	}
-	if err := r.innerKey.UnmarshalCBOR(keyBytes); err != nil {
-		return fmt.Errorf("decode key: %w", err)
-	}
-
+	r.innerClientID = id
 	return nil
 }
 
@@ -143,7 +115,7 @@ PersistentKeepalive = 25
 `
 
 // WGRegisterRequest is the request body for WireGuard device registration.
-// Embeds WGBaseRequest for common authentication fields.
+// Embeds WGBaseRequest for the target client_id.
 type WGRegisterRequest struct {
 	WGBaseRequest
 	WGPubkey string `json:"wg_pubkey"`
@@ -169,7 +141,7 @@ type WGRegisterResponse struct {
 }
 
 // WGProfileRequest is the request body for WireGuard profile generation.
-// Embeds WGBaseRequest for common authentication fields.
+// Embeds WGBaseRequest for the target client_id.
 type WGProfileRequest struct {
 	WGBaseRequest
 	WGPubkey string `json:"wg_pubkey"`
@@ -186,7 +158,7 @@ func (r *WGProfileRequest) UnmarshalJSON(data []byte) error {
 }
 
 // WGDeleteRequest is the request body for WireGuard device deletion.
-// Embeds WGBaseRequest for common authentication fields.
+// Embeds WGBaseRequest for the target client_id.
 type WGDeleteRequest struct {
 	WGBaseRequest
 	WGPubkey string `json:"wg_pubkey"`
@@ -209,7 +181,7 @@ type WGDeleteResponse struct {
 }
 
 // WGDevicesRequest is the request body for listing WireGuard devices.
-// Only uses the base authentication fields, no additional fields needed.
+// Only needs the base client_id field.
 type WGDevicesRequest struct {
 	WGBaseRequest
 }
@@ -252,81 +224,6 @@ func writeErrorResponse(w http.ResponseWriter, status int, err, reason string) {
 	_, _ = w.Write(data)
 }
 
-// verifyCOSESignature verifies a COSE signature and validates the credential.
-// Returns the database client if successful.
-func (a *Api) verifyCOSESignature(
-	clientID string,
-	innerClientID []byte,
-	innerSignature *cose.UntaggedSign1Message,
-	innerKey *cose.Key,
-) (*database.Client, error) {
-	// Lookup client in database
-	tmpClient, err := a.db.ClientByAssetName(innerClientID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to lookup client: %w", err)
-	}
-
-	// Verify challenge string meets requirements
-	// Payload must contain at least clientID + 1 digit for timestamp
-	if len(innerSignature.Payload) < len(clientID)+1 {
-		return nil, errors.New(
-			"challenge payload too short: must contain client ID and timestamp",
-		)
-	}
-	challengeClientId := string(innerSignature.Payload[0:len(clientID)])
-	if challengeClientId != clientID {
-		return nil, errors.New("challenge string does not match client ID")
-	}
-	challengeTimestamp := string(
-		innerSignature.Payload[len(challengeClientId):],
-	)
-	tmpTimestamp, err := strconv.ParseInt(challengeTimestamp, 10, 64)
-	if err != nil {
-		return nil, errors.New(
-			"could not extract timestamp from challenge string",
-		)
-	}
-	timestamp := time.Unix(tmpTimestamp, 0)
-	age := time.Since(timestamp)
-	// Reject timestamps too far in the future (negative age beyond skew window)
-	// to prevent replay attacks while allowing small clock differences
-	if age < -TimestampFutureSkewWindow {
-		return nil, errors.New(
-			"challenge string timestamp is too far in the future",
-		)
-	}
-	if age > TimestampValidityWindow {
-		return nil, errors.New("challenge string timestamp is too old")
-	}
-
-	// Verify challenge signature
-	vkey, err := innerKey.PublicKey()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get public key: %w", err)
-	}
-	verifier, err := cose.NewVerifier(cose.AlgorithmEdDSA, vkey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create verifier: %w", err)
-	}
-	if err := innerSignature.Verify(nil, verifier); err != nil {
-		return nil, errors.New("failed to validate signature")
-	}
-
-	// Check that signing key matches known client credential
-	ed25519Key, ok := vkey.(ed25519.PublicKey)
-	if !ok {
-		return nil, errors.New("public key is not Ed25519")
-	}
-	vkeyHash := lcommon.Blake2b224Hash([]byte(ed25519Key))
-	if subtle.ConstantTimeCompare(vkeyHash.Bytes(), tmpClient.Credential) != 1 {
-		return nil, errors.New(
-			"key hash does not match credential for client",
-		)
-	}
-
-	return &tmpClient, nil
-}
-
 // wgRegisterImpl handles POST /api/client/wg-register
 //
 //	@Summary		WGRegister
@@ -340,6 +237,7 @@ func (a *Api) verifyCOSESignature(
 //	@Failure		403					{object}	ErrorResponse		"Forbidden (device limit reached or subscription expired)"
 //	@Failure		405					{object}	string				"Method Not Allowed"
 //	@Failure		500					{object}	ErrorResponse		"Server Error"
+//	@Security		BearerAuth
 //	@Router			/api/client/wg-register [post]
 func (a *Api) wgRegisterImpl(
 	w http.ResponseWriter,
@@ -384,20 +282,15 @@ func (a *Api) wgRegisterImpl(
 		return
 	}
 
-	// Verify COSE signature
-	tmpClient, err := a.verifyCOSESignature(
-		req.ClientID,
-		req.innerClientID,
-		&req.innerSignature,
-		&req.innerKey,
-	)
+	// Authenticate via session token
+	tmpClient, err := a.authenticate(r, req.innerClientID)
 	if err != nil {
-		slog.Error("COSE verification failed", "error", err)
+		slog.Error("authentication failed", "error", err)
 		writeErrorResponse(
 			w,
 			http.StatusUnauthorized,
 			"Unauthorized",
-			"signature verification failed",
+			"authentication failed",
 		)
 		return
 	}
@@ -588,6 +481,7 @@ func (a *Api) wgRegisterImpl(
 //	@Failure		404					{object}	ErrorResponse		"Not Found"
 //	@Failure		405					{object}	string				"Method Not Allowed"
 //	@Failure		500					{object}	ErrorResponse		"Server Error"
+//	@Security		BearerAuth
 //	@Router			/api/client/wg-profile [post]
 func (a *Api) wgProfileImpl(
 	w http.ResponseWriter,
@@ -630,20 +524,15 @@ func (a *Api) wgProfileImpl(
 		return
 	}
 
-	// Verify COSE signature
-	tmpClient, err := a.verifyCOSESignature(
-		req.ClientID,
-		req.innerClientID,
-		&req.innerSignature,
-		&req.innerKey,
-	)
+	// Authenticate via session token
+	tmpClient, err := a.authenticate(r, req.innerClientID)
 	if err != nil {
-		slog.Error("COSE verification failed", "error", err)
+		slog.Error("authentication failed", "error", err)
 		writeErrorResponse(
 			w,
 			http.StatusUnauthorized,
 			"Unauthorized",
-			"signature verification failed",
+			"authentication failed",
 		)
 		return
 	}
@@ -748,6 +637,7 @@ func (a *Api) wgProfileImpl(
 //	@Failure		404				{object}	ErrorResponse		"Not Found"
 //	@Failure		405				{object}	string				"Method Not Allowed"
 //	@Failure		500				{object}	ErrorResponse		"Server Error"
+//	@Security		BearerAuth
 //	@Router			/api/client/wg-peer [delete]
 func (a *Api) wgPeerDeleteImpl(
 	w http.ResponseWriter,
@@ -792,20 +682,23 @@ func (a *Api) wgPeerDeleteImpl(
 		return
 	}
 
-	// Verify COSE signature
-	_, err := a.verifyCOSESignature(
-		req.ClientID,
-		req.innerClientID,
-		&req.innerSignature,
-		&req.innerKey,
-	)
+	// Authenticate via session token
+	tmpClient, err := a.authenticate(r, req.innerClientID)
 	if err != nil {
-		slog.Error("COSE verification failed", "error", err)
+		slog.Error("authentication failed", "error", err)
 		writeErrorResponse(
 			w,
 			http.StatusUnauthorized,
 			"Unauthorized",
-			"signature verification failed",
+			"authentication failed",
+		)
+		return
+	}
+
+	// Check subscription not expired
+	if time.Now().After(tmpClient.Expiration) {
+		writeErrorResponse(
+			w, http.StatusForbidden, "Forbidden", "subscription has expired",
 		)
 		return
 	}
@@ -935,6 +828,7 @@ func (a *Api) wgPeerDeleteImpl(
 //	@Failure		401					{object}	ErrorResponse		"Unauthorized"
 //	@Failure		405					{object}	string				"Method Not Allowed"
 //	@Failure		500					{object}	ErrorResponse		"Server Error"
+//	@Security		BearerAuth
 //	@Router			/api/client/wg-devices [post]
 func (a *Api) wgDevicesImpl(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -954,20 +848,23 @@ func (a *Api) wgDevicesImpl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify COSE signature
-	_, err := a.verifyCOSESignature(
-		req.ClientID,
-		req.innerClientID,
-		&req.innerSignature,
-		&req.innerKey,
-	)
+	// Authenticate via session token
+	tmpClient, err := a.authenticate(r, req.innerClientID)
 	if err != nil {
-		slog.Error("COSE verification failed", "error", err)
+		slog.Error("authentication failed", "error", err)
 		writeErrorResponse(
 			w,
 			http.StatusUnauthorized,
 			"Unauthorized",
-			"signature verification failed",
+			"authentication failed",
+		)
+		return
+	}
+
+	// Check subscription not expired
+	if time.Now().After(tmpClient.Expiration) {
+		writeErrorResponse(
+			w, http.StatusForbidden, "Forbidden", "subscription has expired",
 		)
 		return
 	}

--- a/internal/api/wireguard_test.go
+++ b/internal/api/wireguard_test.go
@@ -90,24 +90,27 @@ func TestWGRegisterRequestUnmarshal(t *testing.T) {
 		shouldError bool
 	}{
 		{
-			name:        "empty object",
-			json:        `{}`,
-			shouldError: true, // hex decode fails on empty string
+			name: "empty object",
+			json: `{}`,
+			// Empty client_id decodes to empty bytes; authentication (and the
+			// requirement for a client_id) is enforced later in the handler.
+			shouldError: false,
 		},
 		{
 			name:        "invalid client_id hex",
-			json:        `{"client_id": "not-hex", "wg_pubkey": "test", "timestamp": 123, "signature": "abc", "key": "def"}`,
+			json:        `{"client_id": "not-hex", "wg_pubkey": "test"}`,
 			shouldError: true,
 		},
 		{
-			name:        "invalid signature hex",
-			json:        `{"client_id": "0123456789abcdef", "wg_pubkey": "testkey", "timestamp": 123, "signature": "not-hex", "key": "abcd"}`,
-			shouldError: true,
+			name:        "valid client_id",
+			json:        `{"client_id": "0123456789abcdef", "wg_pubkey": "testkey"}`,
+			shouldError: false,
 		},
 		{
-			name:        "valid hex but invalid CBOR",
-			json:        `{"client_id": "0123456789abcdef", "wg_pubkey": "testkey", "timestamp": 123, "signature": "abcd", "key": "1234"}`,
-			shouldError: true, // CBOR unmarshalling will fail
+			name: "ignores legacy signature and key fields",
+			json: `{"client_id": "0123456789abcdef", "wg_pubkey": "testkey", "signature": "not-hex", "key": "not-hex"}`,
+			// signature/key are no longer part of the request; they are ignored.
+			shouldError: false,
 		},
 	}
 
@@ -225,29 +228,23 @@ func TestWGBaseRequestParseFields(t *testing.T) {
 		{
 			name: "invalid client_id hex",
 			req: WGBaseRequest{
-				ClientID:  "not-valid-hex",
-				Signature: "abcd",
-				Key:       "1234",
+				ClientID: "not-valid-hex",
 			},
 			shouldError: true,
 		},
 		{
-			name: "invalid signature hex",
+			name: "valid client_id hex",
 			req: WGBaseRequest{
-				ClientID:  "0123456789abcdef",
-				Signature: "not-valid-hex",
-				Key:       "1234",
+				ClientID: "0123456789abcdef",
 			},
-			shouldError: true,
+			shouldError: false,
 		},
 		{
-			name: "invalid key hex",
+			name: "empty client_id",
 			req: WGBaseRequest{
-				ClientID:  "0123456789abcdef",
-				Signature: "abcd",
-				Key:       "not-valid-hex",
+				ClientID: "",
 			},
-			shouldError: true,
+			shouldError: false,
 		},
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,12 +89,15 @@ type VpnConfig struct {
 	Region string `yaml:"region"         envconfig:"VPN_REGION"`
 	Port   int    `yaml:"port"           envconfig:"VPN_PORT"`
 	DNS    string `yaml:"dns"            envconfig:"VPN_DNS"`
+	// JWTKeyFile is the Ed25519 private key used to sign API session tokens
+	// (required for all protocols) and to authenticate the indexer to the
+	// WireGuard container.
+	JWTKeyFile string `yaml:"jwtKeyFile"     envconfig:"VPN_JWT_KEY_FILE"` // Path to Ed25519 private key (required)
 	// WireGuard configuration (disabled by default, set Protocol to "wireguard" to enable)
 	Protocol         string        `yaml:"protocol"       envconfig:"VPN_PROTOCOL"`             // "openvpn" (default) or "wireguard"
 	WGEndpoint       string        `yaml:"wgEndpoint"     envconfig:"VPN_WG_ENDPOINT"`          // e.g., "us1.vpn.b7s.services:51820"
 	WGContainerURL   string        `yaml:"wgContainerURL" envconfig:"VPN_WG_CONTAINER_URL"`     // e.g., "http://wg-us1:8080"
 	WGServerPubkey   string        `yaml:"wgServerPubkey" envconfig:"VPN_WG_SERVER_PUBKEY"`     // Base64 WG server public key
-	WGJWTKeyFile     string        `yaml:"wgJwtKeyFile"   envconfig:"VPN_WG_JWT_KEY_FILE"`      // Path to Ed25519 private key
 	WGMaxDevices     int           `yaml:"wgMaxDevices"   envconfig:"VPN_WG_MAX_DEVICES"`       // Default: 3
 	WGSubnet         string        `yaml:"wgSubnet"       envconfig:"VPN_WG_SUBNET"`            // Default: "10.8.0" (forms 10.8.0.X)
 	WGExpireInterval time.Duration `yaml:"wgExpireInterval" envconfig:"VPN_WG_EXPIRE_INTERVAL"` // Default: 1h
@@ -207,6 +210,12 @@ func Load(configFile string) (*Config, error) {
 		)
 	}
 
+	// The JWT key is required for all protocols: it signs the session tokens
+	// used to authenticate every API client.
+	if err := validateJWTKeyFile(&globalConfig.Vpn); err != nil {
+		return nil, err
+	}
+
 	// Validate WireGuard configuration if enabled
 	if globalConfig.Vpn.Protocol == "wireguard" {
 		if err := validateWireGuardConfig(&globalConfig.Vpn); err != nil {
@@ -215,6 +224,28 @@ func Load(configFile string) (*Config, error) {
 	}
 
 	return globalConfig, nil
+}
+
+// validateJWTKeyFile ensures the Ed25519 key used to sign session tokens (all
+// protocols) and to authenticate to the WireGuard container is configured and
+// readable.
+func validateJWTKeyFile(vpn *VpnConfig) error {
+	// Validate the path as configured (no trimming): surrounding whitespace
+	// should fail here rather than later when jwt.NewIssuer opens the raw value.
+	if vpn.JWTKeyFile == "" {
+		return fmt.Errorf("JWTKeyFile is required")
+	}
+	f, err := os.Open(vpn.JWTKeyFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("JWTKeyFile %q does not exist", vpn.JWTKeyFile)
+		}
+		return fmt.Errorf("JWTKeyFile %q is not readable: %w", vpn.JWTKeyFile, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("JWTKeyFile %q close failed: %w", vpn.JWTKeyFile, err)
+	}
+	return nil
 }
 
 // validateWireGuardConfig validates WireGuard-specific configuration
@@ -228,33 +259,6 @@ func validateWireGuardConfig(vpn *VpnConfig) error {
 	}
 	if strings.TrimSpace(vpn.WGServerPubkey) == "" {
 		return fmt.Errorf("WGServerPubkey is required for WireGuard protocol")
-	}
-	if strings.TrimSpace(vpn.WGJWTKeyFile) == "" {
-		return fmt.Errorf("WGJWTKeyFile is required for WireGuard protocol")
-	}
-
-	// Validate WGJWTKeyFile is readable by actually opening it
-	jwtKeyPath := strings.TrimSpace(vpn.WGJWTKeyFile)
-	if f, err := os.Open(jwtKeyPath); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf(
-				"WGJWTKeyFile %q does not exist",
-				jwtKeyPath,
-			)
-		}
-		return fmt.Errorf(
-			"WGJWTKeyFile %q is not readable: %w",
-			jwtKeyPath,
-			err,
-		)
-	} else {
-		if err := f.Close(); err != nil {
-			return fmt.Errorf(
-				"WGJWTKeyFile %q close failed: %w",
-				jwtKeyPath,
-				err,
-			)
-		}
 	}
 
 	// Validate WGSubnet format (should be like "10.8.0" - first 3 octets)

--- a/internal/jwt/issuer.go
+++ b/internal/jwt/issuer.go
@@ -26,8 +26,10 @@ import (
 )
 
 // Issuer handles Ed25519 JWT signing for WireGuard peer authentication
+// and browser session tokens.
 type Issuer struct {
 	privateKey ed25519.PrivateKey
+	publicKey  ed25519.PublicKey
 }
 
 // NewIssuer loads an Ed25519 private key from a PEM file
@@ -53,8 +55,12 @@ func NewIssuer(keyFile string) (*Issuer, error) {
 		return nil, errors.New("key is not an Ed25519 private key")
 	}
 
+	// ed25519.PrivateKey.Public() always returns an ed25519.PublicKey.
+	publicKey := ed25519Key.Public().(ed25519.PublicKey)
+
 	return &Issuer{
 		privateKey: ed25519Key,
+		publicKey:  publicKey,
 	}, nil
 }
 
@@ -84,4 +90,88 @@ func (i *Issuer) IssuePeerJWT(pubkey, allowedIP string) (string, error) {
 	}
 
 	return signedToken, nil
+}
+
+// SessionJWTLifetime is the validity period for browser session tokens.
+// Kept short so the lack of explicit revocation is acceptable; subscription
+// expiry is still re-checked against the database on every operation.
+const SessionJWTLifetime = 30 * time.Minute
+
+// sessionAudience identifies session tokens, distinguishing them from peer
+// tokens so the two can never be used interchangeably.
+const sessionAudience = "session"
+
+// IssueSessionJWT creates a short-lived session token bound to a subject
+// (the wallet credential). It returns the signed token and the token's
+// authoritative expiry time, so callers can report expiry without re-deriving
+// it from a second clock read (which could differ from the exp claim by up to
+// a second).
+// Claims: sub=<subject>, aud="session", iat, exp
+func (i *Issuer) IssueSessionJWT(subject string) (string, time.Time, error) {
+	if subject == "" {
+		return "", time.Time{}, errors.New("subject is required")
+	}
+	now := time.Now()
+	expiresAt := now.Add(SessionJWTLifetime)
+
+	claims := jwt.MapClaims{
+		"sub": subject,
+		"aud": sessionAudience,
+		"iat": now.Unix(),
+		"exp": expiresAt.Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+
+	signedToken, err := token.SignedString(i.privateKey)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	return signedToken, expiresAt, nil
+}
+
+// VerifySessionJWT validates a session token and returns its subject claim
+// (the wallet credential). It enforces the EdDSA signing method, the "session"
+// audience, expiry, and issued-at. Peer tokens (which lack the session
+// audience) are rejected.
+func (i *Issuer) VerifySessionJWT(tokenString string) (string, error) {
+	token, err := jwt.Parse(
+		tokenString,
+		func(_ *jwt.Token) (any, error) {
+			return i.publicKey, nil
+		},
+		jwt.WithValidMethods([]string{jwt.SigningMethodEdDSA.Alg()}),
+		jwt.WithAudience(sessionAudience),
+		jwt.WithExpirationRequired(),
+		// Allow small amount of clock skew with freshly issued tokens
+		jwt.WithLeeway(2*time.Second),
+		jwt.WithIssuedAt(),
+	)
+	if err != nil {
+		return "", err
+	}
+	// No explicit token.Valid check: jwt.Parse returns a non-nil error for any
+	// validation failure and only leaves err nil on success, so reaching here
+	// means the token is valid.
+
+	// WithIssuedAt only validates iat when present; require it explicitly so a
+	// token without iat is rejected (matching the mandatory exp claim).
+	iat, err := token.Claims.GetIssuedAt()
+	if err != nil {
+		return "", err
+	}
+	if iat == nil {
+		return "", errors.New("session token missing issued-at")
+	}
+
+	clientID, err := token.Claims.GetSubject()
+	if err != nil {
+		return "", err
+	}
+	if clientID == "" {
+		return "", errors.New("session token missing subject")
+	}
+
+	return clientID, nil
 }

--- a/internal/jwt/issuer_test.go
+++ b/internal/jwt/issuer_test.go
@@ -29,42 +29,16 @@ import (
 )
 
 // generateTestEd25519Key creates a test Ed25519 private key PEM file
-// and returns the path to the file
+// and returns the path to the file along with the corresponding public key.
 func generateTestEd25519Key(t *testing.T) (string, ed25519.PublicKey) {
 	t.Helper()
 
-	// Generate Ed25519 key pair
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("failed to generate Ed25519 key: %v", err)
 	}
 
-	// Marshal private key to PKCS8 format
-	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(privKey)
-	if err != nil {
-		t.Fatalf("failed to marshal private key: %v", err)
-	}
-
-	// Create PEM block
-	pemBlock := &pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: privKeyBytes,
-	}
-
-	// Write to temp file
-	tmpDir := t.TempDir()
-	keyPath := filepath.Join(tmpDir, "ed25519.key")
-	keyFile, err := os.Create(keyPath)
-	if err != nil {
-		t.Fatalf("failed to create key file: %v", err)
-	}
-	defer func() { _ = keyFile.Close() }()
-
-	if err := pem.Encode(keyFile, pemBlock); err != nil {
-		t.Fatalf("failed to write PEM data: %v", err)
-	}
-
-	return keyPath, pubKey
+	return writeTestKeyFile(t, privKey), pubKey
 }
 
 func TestNewIssuerWithValidKey(t *testing.T) {
@@ -315,5 +289,233 @@ func TestIssuePeerJWTExpiry(t *testing.T) {
 			expectedDuration,
 			expiryDuration,
 		)
+	}
+}
+
+// writeTestKeyFile marshals an Ed25519 private key to a PKCS8 PEM file and
+// returns its path.
+func writeTestKeyFile(t *testing.T, privKey ed25519.PrivateKey) string {
+	t.Helper()
+	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(privKey)
+	if err != nil {
+		t.Fatalf("failed to marshal private key: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "ed25519.key")
+	keyFile, err := os.Create(keyPath)
+	if err != nil {
+		t.Fatalf("failed to create key file: %v", err)
+	}
+	defer func() { _ = keyFile.Close() }()
+	if err := pem.Encode(
+		keyFile,
+		&pem.Block{Type: "PRIVATE KEY", Bytes: privKeyBytes},
+	); err != nil {
+		t.Fatalf("failed to write PEM data: %v", err)
+	}
+	return keyPath
+}
+
+func TestSessionJWTRoundTrip(t *testing.T) {
+	keyPath, _ := generateTestEd25519Key(t)
+	issuer, err := NewIssuer(keyPath)
+	if err != nil {
+		t.Fatalf("unexpected error creating issuer: %v", err)
+	}
+
+	clientID := "0123456789abcdef"
+	token, _, err := issuer.IssueSessionJWT(clientID)
+	if err != nil {
+		t.Fatalf("unexpected error issuing session token: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token string")
+	}
+
+	got, err := issuer.VerifySessionJWT(token)
+	if err != nil {
+		t.Fatalf("unexpected error verifying session token: %v", err)
+	}
+	if got != clientID {
+		t.Fatalf("expected client ID %q, got %q", clientID, got)
+	}
+}
+
+func TestSessionJWTHasCorrectClaims(t *testing.T) {
+	keyPath, pubKey := generateTestEd25519Key(t)
+	issuer, err := NewIssuer(keyPath)
+	if err != nil {
+		t.Fatalf("unexpected error creating issuer: %v", err)
+	}
+
+	clientID := "0123456789abcdef"
+	tokenString, expiresAt, err := issuer.IssueSessionJWT(clientID)
+	if err != nil {
+		t.Fatalf("unexpected error issuing session token: %v", err)
+	}
+
+	token, err := jwt.Parse(tokenString, func(_ *jwt.Token) (any, error) {
+		return pubKey, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to parse token: %v", err)
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatal("failed to cast claims to MapClaims")
+	}
+
+	if sub, _ := claims["sub"].(string); sub != clientID {
+		t.Fatalf("expected sub %q, got %v", clientID, claims["sub"])
+	}
+	if aud, _ := claims["aud"].(string); aud != sessionAudience {
+		t.Fatalf("expected aud %q, got %v", sessionAudience, claims["aud"])
+	}
+	iat, _ := claims["iat"].(float64)
+	exp, _ := claims["exp"].(float64)
+	if got := int64(exp) - int64(iat); got != int64(SessionJWTLifetime.Seconds()) {
+		t.Fatalf(
+			"expected lifetime %d seconds, got %d",
+			int64(SessionJWTLifetime.Seconds()),
+			got,
+		)
+	}
+	// The returned expiry must exactly match the token's exp claim so the
+	// API's reported expires_at can never disagree with the token.
+	if expiresAt.Unix() != int64(exp) {
+		t.Fatalf(
+			"returned expiry %d does not match exp claim %d",
+			expiresAt.Unix(),
+			int64(exp),
+		)
+	}
+}
+
+func TestVerifySessionJWTRejectsPeerToken(t *testing.T) {
+	keyPath, _ := generateTestEd25519Key(t)
+	issuer, err := NewIssuer(keyPath)
+	if err != nil {
+		t.Fatalf("unexpected error creating issuer: %v", err)
+	}
+
+	// A peer token lacks the "session" audience and must be rejected.
+	peerToken, err := issuer.IssuePeerJWT("somepubkey", "10.8.0.2")
+	if err != nil {
+		t.Fatalf("unexpected error issuing peer token: %v", err)
+	}
+	if _, err := issuer.VerifySessionJWT(peerToken); err == nil {
+		t.Fatal("expected peer token to be rejected as a session token")
+	}
+}
+
+func TestVerifySessionJWTRejectsExpired(t *testing.T) {
+	_, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	issuer, err := NewIssuer(writeTestKeyFile(t, privKey))
+	if err != nil {
+		t.Fatalf("unexpected error creating issuer: %v", err)
+	}
+
+	// Craft an already-expired session token signed by the issuer's key.
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"sub": "0123456789abcdef",
+		"aud": sessionAudience,
+		"iat": now.Add(-2 * time.Hour).Unix(),
+		"exp": now.Add(-1 * time.Hour).Unix(),
+	}
+	expired, err := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims).
+		SignedString(privKey)
+	if err != nil {
+		t.Fatalf("failed to sign expired token: %v", err)
+	}
+
+	if _, err := issuer.VerifySessionJWT(expired); err == nil {
+		t.Fatal("expected expired session token to be rejected")
+	}
+}
+
+func TestVerifySessionJWTRejectsMissingExp(t *testing.T) {
+	_, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	issuer, err := NewIssuer(writeTestKeyFile(t, privKey))
+	if err != nil {
+		t.Fatalf("unexpected error creating issuer: %v", err)
+	}
+
+	// A token without an exp claim must be rejected (no non-expiring tokens).
+	claims := jwt.MapClaims{
+		"sub": "0123456789abcdef",
+		"aud": sessionAudience,
+		"iat": time.Now().Unix(),
+	}
+	noExp, err := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims).
+		SignedString(privKey)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	if _, err := issuer.VerifySessionJWT(noExp); err == nil {
+		t.Fatal("expected session token without exp to be rejected")
+	}
+}
+
+func TestVerifySessionJWTRejectsMissingIssuedAt(t *testing.T) {
+	_, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	issuer, err := NewIssuer(writeTestKeyFile(t, privKey))
+	if err != nil {
+		t.Fatalf("unexpected error creating issuer: %v", err)
+	}
+
+	// A token without an iat claim must be rejected.
+	claims := jwt.MapClaims{
+		"sub": "0123456789abcdef",
+		"aud": sessionAudience,
+		"exp": time.Now().Add(SessionJWTLifetime).Unix(),
+	}
+	noIat, err := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims).
+		SignedString(privKey)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	if _, err := issuer.VerifySessionJWT(noIat); err == nil {
+		t.Fatal("expected session token without iat to be rejected")
+	}
+}
+
+func TestVerifySessionJWTRejectsWrongKey(t *testing.T) {
+	keyPath, _ := generateTestEd25519Key(t)
+	issuer, err := NewIssuer(keyPath)
+	if err != nil {
+		t.Fatalf("unexpected error creating issuer: %v", err)
+	}
+
+	// Sign a valid-looking session token with a different key.
+	_, otherPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"sub": "0123456789abcdef",
+		"aud": sessionAudience,
+		"iat": now.Unix(),
+		"exp": now.Add(SessionJWTLifetime).Unix(),
+	}
+	forged, err := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims).
+		SignedString(otherPriv)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	if _, err := issuer.VerifySessionJWT(forged); err == nil {
+		t.Fatal("expected token signed with wrong key to be rejected")
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch API auth to short‑lived Bearer session tokens signed with one global Ed25519 JWT key. Adds `POST /api/auth/session` and requires Bearer tokens on WireGuard and Client Profile routes; enforces wallet ownership and subscription expiry.

- **New Features**
  - `POST /api/auth/session` exchanges a wallet‑signed `"vpn-session:<unix>"` COSE challenge for a 30‑minute session JWT; wallet must own at least one subscription; returns `expires_at`.
  - Session JWTs: Ed25519, `aud="session"`, `iat/exp` required, `sub=<wallet credential hex>`; peer tokens are rejected as sessions.
  - Unified auth extracts Bearer and authorizes body `client_id` against the token’s wallet credential; Client Profile and WG `devices`/`peer delete` also reject expired subscriptions; consistent 401 vs 500 auth errors.
  - Swagger adds `BearerAuth` and marks protected routes; request models drop `signature`/`key`. A single issuer from `VPN_JWT_KEY_FILE` is required at startup and also authenticates the indexer to the WireGuard container; `/api/auth/session` is always available.

- **Migration**
  - Set `VPN_JWT_KEY_FILE` (remove `VPN_WG_JWT_KEY_FILE`).
  - Get a token: `POST /api/auth/session` with a COSE signature over `"vpn-session:<unix>"` and the public key.
  - Use it by sending `Authorization: Bearer <token>` to WireGuard and Client Profile endpoints; include `client_id`. Remove `signature` and `key` from requests.

<sup>Written for commit 7ad6d1fcbe0b03379d6646517e7282ab78fae39e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-indexer/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /api/auth/session` to exchange a wallet-signed challenge for short-lived session tokens.
  * Enabled bearer session-token authorization across protected API and WireGuard endpoints.
* **Bug Fixes**
  * Switched WireGuard/API auth flow to use session-token verification (no legacy COSE signature/key checks).
  * Added fail-fast validation for missing session JWT issuer and aligned subscription-expiry enforcement with authenticated requests.
* **Documentation**
  * Updated Swagger docs and request/response schemas to reflect session-based Bearer auth and removed legacy `signature`/`key` fields.
* **Tests**
  * Expanded session-JWT tests and updated WireGuard request parsing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->