### PR TITLE
fix: use correct event type for updated adder

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -180,7 +180,7 @@ func (i *Indexer) Start(
 	// Configure pipeline filters
 	// We only care about transaction events
 	filterEvent := filter_event.New(
-		filter_event.WithTypes([]string{"chainsync.transaction"}),
+		filter_event.WithTypes([]string{"input.transaction"}),
 	)
 	i.pipeline.AddFilter(filterEvent)
 	// We only care about transactions involving our script address


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the pipeline filter to listen for "input.transaction" events instead of "chainsync.transaction". This ensures the indexer processes transaction events from the updated event source.

<sup>Written for commit 047b52843fc6aed75c3643b290402db43a2d549b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-indexer/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event handling so transaction events are picked up correctly during indexing, improving pipeline processing and data flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->