### PR TITLE
chore: upgrade Go to 1.26

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blinklabs-io/vpn-indexer
 
-go 1.25.8
+go 1.26.0
 
 require (
 	github.com/Salvionied/apollo v1.8.0


### PR DESCRIPTION
Closes #357.

Upgrades the indexer to Go 1.26 "for everything." The Dockerfile (`go:1.26.3`), `golangci-lint`, and `publish` workflows were already on 1.26; this brings the remaining pins in line.

## Changes
- `go.mod`: `go 1.25.8` → `go 1.26.0` (matches the migrated sibling repo convention).
- `.github/workflows/go-test.yml`: drop `1.25.x` from the matrix so `go-test` runs on `1.26.x` only.

## Deliberately unchanged
- `openapi/go.mod` stays at `go 1.18`. It's a generated, separately-published client module (`DO NOT EDIT` markers, own module path) that the main module doesn't import; raising its floor would force external consumers onto a newer toolchain rather than upgrade this project.

## Verification
Built, vetted, and tested locally with Go 1.26.3:
- `go build ./...` — OK
- `go vet ./...` — OK
- `go test ./...` — all packages pass
- `go mod verify` — all modules verified; no `go.sum` churn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the indexer to Go 1.26 and standardize CI on 1.26. Removes Go 1.25 from tests to match the Dockerfile, lint, and publish workflows.

- **Dependencies**
  - Update `go.mod` to `go 1.26.0`; keep `openapi/go.mod` at `go 1.18` to avoid breaking downstream clients.
  - Run `.github/workflows/go-test.yml` on `1.26.x` only.

<sup>Written for commit 82564249dc7faf292c2dfaea27b8de328f961e43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-indexer/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

